### PR TITLE
feat: support Ollama with synthetic-data-kit

### DIFF
--- a/synthetic_data_kit/config.yaml
+++ b/synthetic_data_kit/config.yaml
@@ -10,6 +10,7 @@ paths:
     docx: "data/docx"
     ppt: "data/ppt"
     txt: "data/txt"
+    default: "data/input"
   
   # Output locations
   output:
@@ -17,14 +18,25 @@ paths:
     generated: "data/generated" # Where generated content is saved
     cleaned: "data/cleaned"     # Where cleaned content is saved
     final: "data/final"         # Where final formatted content is saved
+    default: "data/output"
 
-# VLLM server configuration
+# LLM Backend Configuration
+backend: "vllm"  # Options: "vllm" or "ollama"
+
+# VLLM Configuration
 vllm:
-  api_base: "http://localhost:8000/v1" # Base URL for VLLM API
-  port: 8000                           # Port for VLLM server
-  model: "meta-llama/Llama-3.3-70B-Instruct" # Default model to use
-  max_retries: 3                       # Number of retries for API calls
-  retry_delay: 1.0                     # Initial delay between retries (seconds)
+  api_base: "http://localhost:8000/v1"
+  port: 8000
+  model: "meta-llama/Llama-3.3-70B-Instruct"
+  max_retries: 3
+  retry_delay: 1.0
+
+# Ollama Configuration
+ollama:
+  api_base: "http://localhost:11434/v1"
+  model: "llama3.2"
+  max_retries: 3
+  retry_delay: 1.0
 
 # Ingest configuration
 ingest:
@@ -44,7 +56,7 @@ generation:
 # Content curation parameters
 curate:
   threshold: 7.0     # Default quality threshold (1-10)
-  batch_size: 32     # Number of items per batch for rating
+  batch_size: 8      # Number of items per batch for rating
   inference_batch: 32 # Number of batches to process at once with VLLM
   temperature: 0.1   # Temperature for rating (lower = more consistent)
 

--- a/synthetic_data_kit/core/save_as.py
+++ b/synthetic_data_kit/core/save_as.py
@@ -10,15 +10,17 @@ import json
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from synthetic_data_kit.models.llm_client import LLMClient
 from synthetic_data_kit.utils.format_converter import to_jsonl, to_alpaca, to_fine_tuning, to_chatml, to_hf_dataset
 from synthetic_data_kit.utils.llm_processing import convert_to_conversation_format
 
-def convert_format(
+def process_file(
     input_path: str,
     output_path: str,
     format_type: str,
-    config: Optional[Dict[str, Any]] = None,
-    storage_format: str = "json",
+    storage_format: str,
+    config_path: Optional[Path] = None,
+    llm_client: Optional[LLMClient] = None,
 ) -> str:
     """Convert data to different formats
     
@@ -26,8 +28,9 @@ def convert_format(
         input_path: Path to the input file
         output_path: Path to save the output
         format_type: Output format (jsonl, alpaca, ft, chatml)
-        config: Configuration dictionary
         storage_format: Storage format, either "json" or "hf" (Hugging Face dataset)
+        config_path: Path to configuration file
+        llm_client: Initialized LLMClient instance
     
     Returns:
         Path to the output file or directory

--- a/synthetic_data_kit/models/llm_backends.py
+++ b/synthetic_data_kit/models/llm_backends.py
@@ -1,0 +1,191 @@
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+import requests
+import json
+import time
+import os
+from pathlib import Path
+
+class BaseLLMBackend(ABC):
+    """Abstract base class for LLM inference backends"""
+    
+    @abstractmethod
+    def check_server(self) -> tuple:
+        """Check if the server is running and accessible"""
+        pass
+    
+    @abstractmethod
+    def chat_completion(self, 
+                       messages: List[Dict[str, str]], 
+                       temperature: float = None,
+                       max_tokens: int = None,
+                       top_p: float = None) -> str:
+        """Generate a chat completion"""
+        pass
+    
+    @abstractmethod
+    def batch_completion(self,
+                        message_batches: List[List[Dict[str, str]]],
+                        temperature: float = None,
+                        max_tokens: int = None,
+                        top_p: float = None,
+                        batch_size: int = None) -> List[str]:
+        """Process multiple message sets in batches"""
+        pass
+
+class VLLMBackend(BaseLLMBackend):
+    """VLLM backend implementation"""
+    
+    def __init__(self, api_base: str, model: str, max_retries: int = 3, retry_delay: float = 1.0):
+        self.api_base = api_base
+        self.model = model
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+    
+    def check_server(self) -> tuple:
+        try:
+            response = requests.get(f"{self.api_base}/models", timeout=5)
+            if response.status_code == 200:
+                return True, response.json()
+            return False, f"Server returned status code: {response.status_code}"
+        except requests.exceptions.RequestException as e:
+            return False, f"Server connection error: {str(e)}"
+    
+    def chat_completion(self, 
+                       messages: List[Dict[str, str]], 
+                       temperature: float = None,
+                       max_tokens: int = None,
+                       top_p: float = None) -> str:
+        data = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature if temperature is not None else 0.7,
+            "max_tokens": max_tokens if max_tokens is not None else 4096,
+            "top_p": top_p if top_p is not None else 0.95
+        }
+        
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.post(
+                    f"{self.api_base}/chat/completions",
+                    headers={"Content-Type": "application/json"},
+                    data=json.dumps(data),
+                    timeout=180
+                )
+                response.raise_for_status()
+                return response.json()["choices"][0]["message"]["content"]
+            except (requests.exceptions.RequestException, KeyError, IndexError) as e:
+                if attempt == self.max_retries - 1:
+                    raise Exception(f"Failed to get completion after {self.max_retries} attempts: {str(e)}")
+                time.sleep(self.retry_delay * (attempt + 1))
+    
+    def batch_completion(self,
+                        message_batches: List[List[Dict[str, str]]],
+                        temperature: float = None,
+                        max_tokens: int = None,
+                        top_p: float = None,
+                        batch_size: int = None) -> List[str]:
+        batch_size = batch_size if batch_size is not None else 32
+        results = []
+        
+        for i in range(0, len(message_batches), batch_size):
+            batch_chunk = message_batches[i:i+batch_size]
+            batch_results = []
+            
+            for messages in batch_chunk:
+                content = self.chat_completion(
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    top_p=top_p
+                )
+                batch_results.append(content)
+            
+            results.extend(batch_results)
+            time.sleep(0.1)
+        
+        return results
+
+class OllamaBackend(BaseLLMBackend):
+    """Ollama backend implementation"""
+    
+    def __init__(self, api_base: str = "http://localhost:11434/v1", model: str = "llama3.2", max_retries: int = 3, retry_delay: float = 1.0):
+        self.api_base = api_base
+        self.model = model
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+    
+    def check_server(self) -> tuple:
+        try:
+            response = requests.get(f"{self.api_base}/models", timeout=5)
+            if response.status_code == 200:
+                return True, response.json()
+            return False, f"Server returned status code: {response.status_code}"
+        except requests.exceptions.RequestException as e:
+            return False, f"Server connection error: {str(e)}"
+    
+    def chat_completion(self, 
+                       messages: List[Dict[str, str]], 
+                       temperature: float = None,
+                       max_tokens: int = None,
+                       top_p: float = None) -> str:
+        data = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature if temperature is not None else 0.7,
+            "max_tokens": max_tokens if max_tokens is not None else 4096,
+            "top_p": top_p if top_p is not None else 0.95
+        }
+        
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.post(
+                    f"{self.api_base}/chat/completions",
+                    headers={"Content-Type": "application/json"},
+                    data=json.dumps(data),
+                    timeout=180
+                )
+                response.raise_for_status()
+                return response.json()["choices"][0]["message"]["content"]
+            except (requests.exceptions.RequestException, KeyError, IndexError) as e:
+                if attempt == self.max_retries - 1:
+                    raise Exception(f"Failed to get completion after {self.max_retries} attempts: {str(e)}")
+                time.sleep(self.retry_delay * (attempt + 1))
+    
+    def batch_completion(self,
+                        message_batches: List[List[Dict[str, str]]],
+                        temperature: float = None,
+                        max_tokens: int = None,
+                        top_p: float = None,
+                        batch_size: int = None) -> List[str]:
+        batch_size = batch_size if batch_size is not None else 32
+        results = []
+        
+        for i in range(0, len(message_batches), batch_size):
+            batch_chunk = message_batches[i:i+batch_size]
+            batch_results = []
+            
+            for messages in batch_chunk:
+                content = self.chat_completion(
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    top_p=top_p
+                )
+                batch_results.append(content)
+            
+            results.extend(batch_results)
+            time.sleep(0.1)
+        
+        return results
+    
+    def list_models(self) -> List[Dict[str, Any]]:
+        """List available Ollama models"""
+        response = requests.get(f"{self.api_base}/models")
+        response.raise_for_status()
+        return response.json()["models"]
+    
+    def check_model_exists(self, model_name: str) -> bool:
+        """Check if a specific model exists"""
+        models = self.list_models()
+        return any(model["name"] == model_name for model in models) 

--- a/synthetic_data_kit/models/llm_client.py
+++ b/synthetic_data_kit/models/llm_client.py
@@ -3,27 +3,30 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# vLLM logic: Will be expanded to ollama and Cerebras in future.
 from typing import List, Dict, Any, Optional
-import requests
-import json
-import time
-import os
 from pathlib import Path
 
-from synthetic_data_kit.utils.config import load_config, get_vllm_config
+from synthetic_data_kit.utils.config import (
+    load_config, 
+    get_backend_type,
+    get_vllm_config, 
+    get_ollama_config
+)
+from synthetic_data_kit.models.llm_backends import VLLMBackend, OllamaBackend
 
 class LLMClient:
     def __init__(self, 
                  config_path: Optional[Path] = None,
+                 backend: Optional[str] = None,
                  api_base: Optional[str] = None, 
                  model_name: Optional[str] = None,
                  max_retries: Optional[int] = None,
                  retry_delay: Optional[float] = None):
-        """Initialize an OpenAI-compatible client that connects to a VLLM server
+        """Initialize an LLM client that supports multiple backends
         
         Args:
             config_path: Path to config file (if None, uses default)
+            backend: Override backend type from config ("vllm" or "ollama")
             api_base: Override API base URL from config
             model_name: Override model name from config
             max_retries: Override max retries from config
@@ -31,70 +34,47 @@ class LLMClient:
         """
         # Load config
         self.config = load_config(config_path)
-        vllm_config = get_vllm_config(self.config)
         
-        # Set parameters, with CLI overrides taking precedence
-        self.api_base = api_base or vllm_config.get('api_base')
-        self.model = model_name or vllm_config.get('model')
-        self.max_retries = max_retries or vllm_config.get('max_retries')
-        self.retry_delay = retry_delay or vllm_config.get('retry_delay')
+        # Determine backend type
+        self.backend_type = backend or get_backend_type(self.config)
+        
+        # Initialize appropriate backend
+        if self.backend_type == "vllm":
+            vllm_config = get_vllm_config(self.config)
+            self.backend = VLLMBackend(
+                api_base=api_base or vllm_config.get('api_base'),
+                model=model_name or vllm_config.get('model'),
+                max_retries=max_retries or vllm_config.get('max_retries'),
+                retry_delay=retry_delay or vllm_config.get('retry_delay')
+            )
+        elif self.backend_type == "ollama":
+            ollama_config = get_ollama_config(self.config)
+            self.backend = OllamaBackend(
+                api_base=api_base or ollama_config.get('api_base'),
+                model=model_name or ollama_config.get('model'),
+                max_retries=max_retries or ollama_config.get('max_retries'),
+                retry_delay=retry_delay or ollama_config.get('retry_delay')
+            )
+        else:
+            raise ValueError(f"Unsupported backend type: {self.backend_type}")
         
         # Verify server is running
-        available, info = self._check_server()
+        available, info = self.backend.check_server()
         if not available:
-            raise ConnectionError(f"VLLM server not available at {self.api_base}: {info}")
-    
-    def _check_server(self) -> tuple:
-        """Check if the VLLM server is running and accessible"""
-        try:
-            response = requests.get(f"{self.api_base}/models", timeout=5)
-            if response.status_code == 200:
-                return True, response.json()
-            return False, f"Server returned status code: {response.status_code}"
-        except requests.exceptions.RequestException as e:
-            return False, f"Server connection error: {str(e)}"
+            raise ConnectionError(f"{self.backend_type.upper()} server not available: {info}")
     
     def chat_completion(self, 
                       messages: List[Dict[str, str]], 
                       temperature: float = None, 
                       max_tokens: int = None,
                       top_p: float = None) -> str:
-        """Generate a chat completion using the VLLM OpenAI-compatible API"""
-        # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        
-        data = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p
-        }
-        
-        for attempt in range(self.max_retries):
-            try:
-                # Only print if verbose mode is enabled
-                if os.environ.get('SDK_VERBOSE', 'false').lower() == 'true':
-                    print(f"Sending request to model {self.model}...")
-                response = requests.post(
-                    f"{self.api_base}/chat/completions",
-                    headers={"Content-Type": "application/json"},
-                    data=json.dumps(data),
-                    timeout=180  # Increased timeout to 180 seconds
-                )
-                if os.environ.get('SDK_VERBOSE', 'false').lower() == 'true':
-                    print(f"Received response with status code: {response.status_code}")
-                
-                response.raise_for_status()
-                return response.json()["choices"][0]["message"]["content"]
-            
-            except (requests.exceptions.RequestException, KeyError, IndexError) as e:
-                if attempt == self.max_retries - 1:
-                    raise Exception(f"Failed to get completion after {self.max_retries} attempts: {str(e)}")
-                time.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
+        """Generate a chat completion using the configured backend"""
+        return self.backend.chat_completion(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p
+        )
     
     def batch_completion(self, 
                        message_batches: List[List[Dict[str, str]]], 
@@ -102,69 +82,26 @@ class LLMClient:
                        max_tokens: int = None,
                        top_p: float = None,
                        batch_size: int = None) -> List[str]:
-        """Process multiple message sets in batches
-        
-        Instead of sending requests one at a time, this method processes
-        multiple prompts in batches to maximize throughput. It uses VLLM's
-        ability to efficiently batch requests.
-        """
-        # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        batch_size = batch_size if batch_size is not None else generation_config.get('batch_size', 32)
-        
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        results = []
-        
-        # Process message batches in chunks to avoid overloading the server
-        for i in range(0, len(message_batches), batch_size):
-            batch_chunk = message_batches[i:i+batch_size]
-            if verbose:
-                print(f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests")
-            
-            # Create batch request payload for VLLM
-            batch_requests = []
-            for messages in batch_chunk:
-                batch_requests.append({
-                    "model": self.model,
-                    "messages": messages,
-                    "temperature": temperature,
-                    "max_tokens": max_tokens,
-                    "top_p": top_p
-                })
-            
-            try:
-                # For now, we run these in parallel with multiple requests
-                batch_results = []
-                for request_data in batch_requests:
-                    # Only print if verbose mode is enabled
-                    if verbose:
-                        print(f"Sending batch request to model {self.model}...")
-                    
-                    response = requests.post(
-                        f"{self.api_base}/chat/completions",
-                        headers={"Content-Type": "application/json"},
-                        data=json.dumps(request_data),
-                        timeout=180  # Increased timeout for batch processing
-                    )
-                    
-                    if verbose:
-                        print(f"Received response with status code: {response.status_code}")
-                    
-                    response.raise_for_status()
-                    content = response.json()["choices"][0]["message"]["content"]
-                    batch_results.append(content)
-                
-                results.extend(batch_results)
-                
-            except (requests.exceptions.RequestException, KeyError, IndexError) as e:
-                raise Exception(f"Failed to process batch: {str(e)}")
-            
-            time.sleep(0.1)
-        
-        return results
+        """Process multiple message sets in batches using the configured backend"""
+        return self.backend.batch_completion(
+            message_batches=message_batches,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            batch_size=batch_size
+        )
+    
+    def list_models(self) -> List[Dict[str, Any]]:
+        """List available models (Ollama only)"""
+        if self.backend_type == "ollama":
+            return self.backend.list_models()
+        raise NotImplementedError("Model listing is only supported for Ollama backend")
+    
+    def check_model_exists(self, model_name: str) -> bool:
+        """Check if a specific model exists (Ollama only)"""
+        if self.backend_type == "ollama":
+            return self.backend.check_model_exists(model_name)
+        raise NotImplementedError("Model existence check is only supported for Ollama backend")
     
     @classmethod
     def from_config(cls, config_path: Path) -> 'LLMClient':

--- a/synthetic_data_kit/utils/config.py
+++ b/synthetic_data_kit/utils/config.py
@@ -60,12 +60,25 @@ def get_path_config(config: Dict[str, Any], path_type: str, file_type: Optional[
     else:
         raise ValueError(f"Unknown path type: {path_type}")
 
+def get_backend_type(config: Dict[str, Any]) -> str:
+    """Get the LLM backend type from configuration"""
+    return config.get('backend', 'vllm')
+
 def get_vllm_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Get VLLM configuration"""
     return config.get('vllm', {
         'api_base': 'http://localhost:8000/v1',
         'port': 8000,
         'model': 'meta-llama/Llama-3.3-70B-Instruct',
+        'max_retries': 3,
+        'retry_delay': 1.0
+    })
+
+def get_ollama_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Get Ollama configuration"""
+    return config.get('ollama', {
+        'api_base': 'http://localhost:11434/v1',
+        'model': 'llama3.2',
         'max_retries': 3,
         'retry_delay': 1.0
     })


### PR DESCRIPTION
# Ollama Backend Integration

Resolves #3 

## Changes
- Added dual backend system with abstract `BaseLLMBackend` class
- Implemented `OllamaBackend` with OpenAI-compatible API support
- Updated `LLMClient` to support backend selection (vLLM/Ollama)
- Added Ollama configuration in YAML with model, API, and retry settings
- Enhanced `system-check` command to display available Ollama models

## Testing
- Tested with Ollama models: llama3.2, qwen3, phi3
- Verified compatibility with existing QA, CoT, and summary generation
- Confirmed model listing and availability checks

## Documentation
- Updated README with Ollama setup and usage instructions
- Added backend-specific troubleshooting guides
- Added example commands for both vLLM and Ollama workflows

## Migration
No breaking changes. Existing vLLM users can continue using the default backend.