### PR TITLE
Feature: Add API_KEY option for CLI

### DIFF
--- a/synthetic_data_kit/cli.py
+++ b/synthetic_data_kit/cli.py
@@ -46,6 +46,9 @@ def callback(
 def system_check(
     api_base: Optional[str] = typer.Option(
         None, "--api-base", help="VLLM API base URL to check"
+    ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="API key for authentication"
     )
 ):
     """
@@ -54,10 +57,14 @@ def system_check(
     # Get VLLM server details from args or config
     vllm_config = get_vllm_config(ctx.config)
     api_base = api_base or vllm_config.get("api_base")
+    api_key = api_key or vllm_config.get("api_key")
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     
     with console.status(f"Checking VLLM server at {api_base}..."):
         try:
-            response = requests.get(f"{api_base}/models", timeout=2)
+            response = requests.get(f"{api_base}/models", headers=headers, timeout=2)
             if response.status_code == 200:
                 console.print(f" VLLM server is running at {api_base}", style="green")
                 console.print(f"Available models: {response.json()}")
@@ -121,6 +128,9 @@ def create(
     model: Optional[str] = typer.Option(
         None, "--model", "-m", help="Model to use"
     ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="API key for authentication"
+    ),
     num_pairs: Optional[int] = typer.Option(
         None, "--num-pairs", "-n", help="Target number of QA pairs to generate"
     ),
@@ -147,10 +157,14 @@ def create(
     vllm_config = get_vllm_config(ctx.config)
     api_base = api_base or vllm_config.get("api_base")
     model = model or vllm_config.get("model")
+    api_key = api_key or vllm_config.get("api_key")
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     
     # Check server first
     try:
-        response = requests.get(f"{api_base}/models", timeout=2)
+        response = requests.get(f"{api_base}/models", headers=headers, timeout=2)
         if response.status_code != 200:
             console.print(f"L Error: VLLM server not available at {api_base}", style="red")
             console.print("Please start the VLLM server with:", style="yellow")
@@ -201,6 +215,9 @@ def curate(
     model: Optional[str] = typer.Option(
         None, "--model", "-m", help="Model to use"
     ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="API key for authentication"
+    ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Show detailed output"
     ),
@@ -214,10 +231,14 @@ def curate(
     vllm_config = get_vllm_config(ctx.config)
     api_base = api_base or vllm_config.get("api_base")
     model = model or vllm_config.get("model")
+    api_key = api_key or vllm_config.get("api_key")
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     
     # Check server first
     try:
-        response = requests.get(f"{api_base}/models", timeout=2)
+        response = requests.get(f"{api_base}/models", headers=headers, timeout=2)
         if response.status_code != 200:
             console.print(f"L Error: VLLM server not available at {api_base}", style="red")
             console.print("Please start the VLLM server with:", style="yellow")


### PR DESCRIPTION
This pull request introduces support for specifying an API key to authenticate requests to the VLLM server. The API key can now be passed as a CLI option (--api-key) to the relevant commands, or in config file. When provided, the API key is added to the HTTP headers in requests made to the server.

**Changes:**
1. Added an [api_key] CLI option to commands such as [system-check], [create], and [curate]. Also added into [llm_client.py].
2. Modified the server check logic to include an Authorization header when an API key is provided.
3. Ensured backward compatibility by falling back to configuration settings if the CLI option is not used.

**Motivation and Context:**
- Enhances the security of the Synthetic Data Kit by allowing more flexible authentication mechanisms.
- Provides a straightforward way to configure API credentials both via CLI and configuration files.