### PR TITLE
Fix YouTube parser HTTP 400 Bad Request error

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ If you encounter issues with the `curate` command:
 - Ensure required dependencies are installed for specific parsers:
   - PDF: `pip install pdfminer.six`
   - HTML: `pip install beautifulsoup4`
-  - YouTube: `pip install pytube youtube-transcript-api`
+  - YouTube: `pip install pytubefix youtube-transcript-api`
   - DOCX: `pip install python-docx`
   - PPTX: `pip install python-pptx`
 

--- a/synthetic_data_kit/parsers/youtube_parser.py
+++ b/synthetic_data_kit/parsers/youtube_parser.py
@@ -21,7 +21,7 @@ class YouTubeParser:
             Transcript text
         """
         try:
-            from pytube import YouTube
+            from pytubefix import YouTube
             from youtube_transcript_api import YouTubeTranscriptApi
         except ImportError:
             raise ImportError(


### PR DESCRIPTION
# Fix YouTube parser HTTP 400 Bad Request error

## Description
This PR fixes the HTTP 400 Bad Request error occurring with the YouTube parser by replacing `pytube` with `pytubefix`, which is actively maintained and addresses the HTTP 400 error issues present in the original library.

## Changes made
- Replace `pytube` with `pytubefix` in the YouTube parser implementation

## Why this approach
The original `pytube` library is experiencing consistent HTTP 400 errors due to changes in YouTube's API, as documented in numerous issues (e.g., [pytube/pytube#2044](https://github.com/pytube/pytube/issues/2044)). The `pytubefix` library is a fork that's actively maintained and specifically addresses these issues.

## Testing
Tested by successfully downloading YouTube video transcripts that previously failed with HTTP 400 errors.

## Demo

### Before
https://github.com/user-attachments/assets/a1d299fe-a902-4016-975b-d31c7df38b1d

### After
https://github.com/user-attachments/assets/839c258d-4753-4fcc-aaf7-2952b2826045



