### PR TITLE
fix: enables detection of pdf in URLs, and parsing of pdf content via URL

### DIFF
--- a/synthetic_data_kit/parsers/pdf_parser.py
+++ b/synthetic_data_kit/parsers/pdf_parser.py
@@ -5,33 +5,60 @@
 # the root directory of this source tree.
 # PDF parser logic
 import os
+import tempfile
+import requests
 from typing import Dict, Any
+from urllib.parse import urlparse
+
 
 class PDFParser:
     """Parser for PDF documents"""
-    
+
     def parse(self, file_path: str) -> str:
         """Parse a PDF file into plain text
-        
+
         Args:
             file_path: Path to the PDF file
-            
+
         Returns:
             Extracted text from the PDF
         """
         try:
             from pdfminer.high_level import extract_text
-            return extract_text(file_path)
         except ImportError:
-            raise ImportError("pdfminer.six is required for PDF parsing. Install it with: pip install pdfminer.six")
-    
+            raise ImportError(
+                "pdfminer.six is required for PDF parsing. Install it with: pip install pdfminer.six"
+            )
+
+        if file_path.startswith(("http://", "https://")):
+            # Download PDF to temporary file
+            response = requests.get(file_path, stream=True)
+            response.raise_for_status()  # Raise error for bad status codes
+
+            # Create temp file with .pdf extension to help with mime type detection
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as temp_file:
+                temp_path = temp_file.name
+                # Write PDF content to temp file
+                for chunk in response.iter_content(chunk_size=8192):
+                    temp_file.write(chunk)
+
+            try:
+                # Parse the downloaded PDF
+                return extract_text(temp_path)
+            finally:
+                # Clean up temp file
+                os.unlink(temp_path)
+        else:
+            # Handle local files as before
+            return extract_text(file_path)
+
     def save(self, content: str, output_path: str) -> None:
         """Save the extracted text to a file
-        
+
         Args:
             content: Extracted text content
             output_path: Path to save the text
         """
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(content)


### PR DESCRIPTION
Closes #25 

Modifies `ingest.py` to correctly dispatch to `PDFParser` based on retrieved content header, and modifies `PDFParser` to retrieve content again and parse from a tempfile.  This isn't super clean, but should be a good starting point for caching & parsing PDFs as the issue identified