### PR TITLE
Fixing #60: Fixing TXT, DOCX, and PPT parser to be compatible with Lance

### DIFF
--- a/synthetic_data_kit/parsers/docx_parser.py
+++ b/synthetic_data_kit/parsers/docx_parser.py
@@ -35,7 +35,8 @@ class DOCXParser:
                 for cell in row.cells:
                     paragraphs.append(cell.text)
         
-        return "\n\n".join(p for p in paragraphs if p)
+        text= "\n\n".join(p for p in paragraphs if p)
+        return [{"text": text}]
     
     def save(self, content: str, output_path: str) -> None:
         """Save the extracted text to a file

--- a/synthetic_data_kit/parsers/ppt_parser.py
+++ b/synthetic_data_kit/parsers/ppt_parser.py
@@ -45,7 +45,8 @@ class PPTParser:
             
             all_text.append("\n".join(slide_text))
         
-        return "\n\n".join(all_text)
+        text = "\n\n".join(all_text)
+        return [{"text": text}]
     
     def save(self, content: str, output_path: str) -> None:
         """Save the extracted text to a file

--- a/synthetic_data_kit/parsers/txt_parser.py
+++ b/synthetic_data_kit/parsers/txt_parser.py
@@ -20,7 +20,7 @@ class TXTParser:
             Text content
         """
         with open(file_path, 'r', encoding='utf-8') as f:
-            return f.read()
+            return [{"text": f.read()}]
     
     def save(self, content: str, output_path: str) -> None:
         """Save the text to a file

--- a/tests/unit/test_additional_parsers.py
+++ b/tests/unit/test_additional_parsers.py
@@ -59,9 +59,9 @@ class TestDOCXParser:
         # Test parsing
         parser = DOCXParser()
         result = parser.parse("/fake/path.docx")
-
+        
         expected = "First paragraph\n\nSecond paragraph\n\nCell 1\n\nCell 2"
-        assert result == expected
+        assert result == [{"text": expected}]
         # Verify docx import was called (first argument of any call should be 'docx')
         import_calls = [call[0][0] for call in mock_import.call_args_list if call[0]]
         assert "docx" in import_calls
@@ -145,7 +145,7 @@ class TestPPTParser:
             "Slide 2 content",
         ]
         expected = "\n\n".join(["\n".join(expected_lines[:4]), "\n".join(expected_lines[5:])])
-        assert result == expected
+        assert result == [{"text": expected}]
         # Verify pptx import was called
         import_calls = [call[0][0] for call in mock_import.call_args_list if call[0]]
         assert "pptx" in import_calls

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -29,15 +29,18 @@ def test_txt_parser():
         # Check that content was extracted correctly
         assert content == [{"text": "This is sample text content for testing."}]
 
+        # Convert content to str
+        text_content = "\n".join([item["text"] for item in content])
+
         # Test saving content
         output_path = os.path.join(tempfile.gettempdir(), "output.txt")
-        parser.save(content, output_path)
+        parser.save(text_content, output_path)
 
         # Check that the file was saved correctly
         with open(output_path) as f:
             saved_content = f.read()
 
-        assert saved_content == content
+        assert saved_content == text_content
     finally:
         # Clean up
         if os.path.exists(file_path):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -27,7 +27,7 @@ def test_txt_parser():
         content = parser.parse(file_path)
 
         # Check that content was extracted correctly
-        assert content == "This is sample text content for testing."
+        assert content == [{"text": "This is sample text content for testing."}]
 
         # Test saving content
         output_path = os.path.join(tempfile.gettempdir(), "output.txt")


### PR DESCRIPTION
# Pull Request

## Description

Please share details of what you have added and why?
Minor bug fix: correcting TXT, DOCX, and PPt parser to return a dictionary with a key "text" instead of raw text, in order to be compatible with Lance.

Fixes # (issue) #60 

## Type of change 

Please non-releavant options

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update