### PR TITLE
fixed requests in batch being actually sequential - https://github.com/meta-llama/synthetic-data-kit/issues/67

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -25,6 +25,7 @@ vllm:
   max_retries: 3                       # Number of retries for API calls
   retry_delay: 1.0                     # Initial delay between retries (seconds)
   sleep_time: 0.1                      # Small delay in seconds between batches to avoid rate limits
+  http_request_timeout: 180            # Http Request timeout in seconds (3 minutes)
   
 # API endpoint configuration
 api-endpoint:


### PR DESCRIPTION
Fixed the requests to be async and concurrent using aiohttp to work correctly.

# Pull Request

## Description

- Modified the synthetic-data-kit/models/llm_client.py function LLMClient._vllm_batch_completion to fix the requests not being concurrent. Now the requests are sent via the aiohttp client in parallel and vLLM backend can process it in parallel.

- Modified the init function for the LLMClient class to expose `http_request_timeout` configuration key for the HTTP Timeout value configuration for all vLLM requests.

Fixes https://github.com/meta-llama/synthetic-data-kit/issues/67

## Type of change

Please non-releavant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Configuration update (added the key `vllm.http_request_timeout` with same default as before)