### PR TITLE
fix: Enhance QA curation to support CoT examples and format conversion

### DIFF
--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -158,11 +158,19 @@ def test_curate_input_validation(patch_config, test_env):
         {
             "question": "What is synthetic data?",
             "answer": "Synthetic data is artificially generated data.",
-        },
+        }
+    ]
+
+    cot_examples = [
+        {
+            "question": "What is synthetic data?",
+            "reasoning": "Synthetic data is artificially generated data.",
+            "answer": "Synthetic data is artificially generated data.",
+        }
     ]
 
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as f:
-        json.dump({"qa_pairs": qa_pairs}, f)
+        json.dump({"qa_pairs": qa_pairs, "cot_examples": cot_examples}, f)
         file_path = f.name
 
     # Create temporary output directory
@@ -182,7 +190,7 @@ def test_curate_input_validation(patch_config, test_env):
                 curate.curate_qa_pairs(input_path=empty_file_path, output_path=output_path)
 
             # Check that the error message is helpful
-            assert "No QA pairs found" in str(excinfo.value)
+            assert "No QA pairs or CoT examples found" in str(excinfo.value)
     finally:
         # Clean up
         if os.path.exists(file_path):


### PR DESCRIPTION
# Pull Request

## Description
I have faced some error while using curate functions, after I created a CoT dataset I wanted to curate them but it gives the error below:
✗ Failed to curate Liar_Truth_cot_examples.json: No QA pairs found in the input file
✗ Failed to curate logical-reasoning-2017-12-02_cot_examples.json: No QA pairs found in the input file

I noticed that the created json files do not have a qa_pairs fields

## Type of change
I add some logics that control if there is a filed of qa_pairs or cot_examples (for cot paires) so it will combain both the qa and cot pairs in json files.

Please non-releavant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update