### PR TITLE
Unify `vllm` and `api-endpoint` providers into a single provider for openai compatible APIs

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -91,7 +91,9 @@ synthetic-data-kit/
 │   │   └── save_as.py        # Format conversion
 │   ├── models/               # LLM integration
 │   │   ├── __init__.py
-│   │   └── llm_client.py     # VLLM client
+│   │   └── llm_client.py     # common LLM interface
+|   │   ├── base.py           # Base class for providers
+│   │   └── openai_provider.py # openai-compatible
 │   ├── parsers/              # Document parsers
 │   │   ├── __init__.py
 │   │   ├── pdf_parser.py     # PDF parser
@@ -142,6 +144,7 @@ classDiagram
         +api_base: str
         +model: str
         +max_retries: int
+        +http_request_timeout: int
         +retry_delay: float
         +config: Dict
         +_check_server() tuple
@@ -539,13 +542,16 @@ paths:
     cleaned: "data/cleaned"
     final: "data/final"
 
-# vllm: Configure VLLM server settings
-vllm:
-  api_base: "http://localhost:8000/v1"
-  port: 8000
-  model: "meta-llama/Llama-3.3-70B-Instruct"
-  max_retries: 3
-  retry_delay: 1.0
+# OpenAI-compatible endpoint configuration
+openai-endpoint:
+  api_base: "https://api.llama.com/v1"    # Base URL for OpenAI-compatible API
+  api_key: "llama-api-key"                # API key for the endpoint (can also use env vars)
+  model: "Llama-4-Maverick-17B-128E-Instruct-FP8" # Default model to use
+  max_retries: 3                          # Number of retries for API calls
+  retry_delay: 1.0                        # Initial delay between retries (seconds)
+  sleep_time: 0.5                         # Pause between batch chunks (seconds)
+  http_request_timeout: 300               # Timeout for HTTP requests (seconds)
+  max_concurrent_requests: 32   
 
 # generation: Content generation parameters
 generation:

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ The toolkit uses a YAML configuration file (default: `configs/config.yaml`).
 Note, this can be overridden via either CLI arguments OR passing a custom YAML file
 
 ```yaml
-# Example configuration using vLLM
+# Example configuration using local openai compatible api (i.e. via `vllm serve`)
 llm:
-  provider: "vllm"
+  provider: "openai-endpoint"
 
-vllm:
+openai-endpoint:
   api_base: "http://localhost:8000/v1"
   model: "meta-llama/Llama-3.3-70B-Instruct"
   sleep_time: 0.1
@@ -175,12 +175,11 @@ curate:
   batch_size: 8
 ```
 
-or using an API endpoint:
-
+or using an external openai compatible api:
 ```yaml
 # Example configuration using the llama API
 llm:
-  provider: "api-endpoint"
+  provider: "openai-endpoint"
 
 api-endpoint:
   api_base: "https://api.llama.com/v1"
@@ -454,6 +453,7 @@ graph LR
 If you encounter CUDA out of memory errors:
 - Use a smaller model
 - Reduce batch size in config
+- Reduce sequence length / max model length (`--max_model_len 12000`)
 - Start vLLM with `--gpu-memory-utilization 0.85`
 
 ### JSON Parsing Issues

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -25,6 +25,7 @@ vllm:
   max_retries: 3                       # Number of retries for API calls
   retry_delay: 1.0                     # Initial delay between retries (seconds)
   sleep_time: 0.1                      # Small delay in seconds between batches to avoid rate limits
+  http_request_timeout: 180            # Http Request timeout in seconds (3 minutes)
   
 # API endpoint configuration
 api-endpoint:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -14,10 +14,10 @@ paths:
 
 # LLM Provider configuration
 llm:
-  # Provider selection: "vllm" or "api-endpoint"
-  provider: "api-endpoint"
+  # Provider selection: "openai-endpoint" (OpenAI-compatible APIs)
+  provider: "openai-endpoint"
 
-# VLLM server configuration
+# Legacy vLLM server configuration (merged automatically into openai-endpoint)
 vllm:
   api_base: "http://localhost:8000/v1" # Base URL for VLLM API
   port: 8000                           # Port for VLLM server
@@ -27,14 +27,16 @@ vllm:
   sleep_time: 0.1                      # Small delay in seconds between batches to avoid rate limits
   http_request_timeout: 180            # Http Request timeout in seconds (3 minutes)
   
-# API endpoint configuration
-api-endpoint:
-  api_base: "https://api.llama.com/v1" # Optional base URL for API endpoint (null for default API)
-  api_key: "llama_api_key"               # API key for API endpoint or compatible service (can use env var instead)
+# OpenAI-compatible endpoint configuration
+openai-endpoint:
+  api_base: "https://api.llama.com/v1"    # Base URL for OpenAI-compatible API
+  api_key: "llama_api_key"               # API key for the endpoint (can also use env vars)
   model: "Llama-4-Maverick-17B-128E-Instruct-FP8" # Default model to use
-  max_retries: 3                       # Number of retries for API calls
-  retry_delay: 1.0                     # Initial delay between retries (seconds)
-  sleep_time: 0.5                      # Small delay in seconds between batches to avoid rate limits
+  max_retries: 3                          # Number of retries for API calls
+  retry_delay: 1.0                        # Initial delay between retries (seconds)
+  sleep_time: 0.5                         # Small delay in seconds between batches to avoid rate limits
+  http_request_timeout: 300               # Timeout for HTTP requests (seconds)
+  max_concurrent_requests: 32             # Maximum concurrent requests during batching
 
 # Ingest configuration
 ingest:

--- a/synthetic_data_kit/cli.py
+++ b/synthetic_data_kit/cli.py
@@ -9,11 +9,15 @@ import os
 import typer
 from pathlib import Path
 from typing import Optional
-import requests
 from rich.console import Console
 from rich.table import Table
 
-from synthetic_data_kit.utils.config import load_config, get_vllm_config, get_openai_config, get_llm_provider, get_path_config
+from synthetic_data_kit.utils.config import (
+    load_config,
+    get_llm_provider,
+    get_path_config,
+    get_provider_config,
+)
 from synthetic_data_kit.core.context import AppContext
 from synthetic_data_kit.server.app import run_server
 
@@ -28,7 +32,6 @@ console = Console()
 # Create app context
 ctx = AppContext()
 
-# Define global options
 @app.callback()
 def callback(
     config: Optional[Path] = typer.Option(
@@ -45,121 +48,91 @@ def callback(
 
 @app.command("system-check")
 def system_check(
-    api_base: Optional[str] = typer.Option(
-        None, "--api-base", help="API base URL to check"
-    ),
+    api_base: Optional[str] = typer.Option(None, "--api-base", help="API base URL to check"),
     provider: Optional[str] = typer.Option(
-        None, "--provider", help="Provider to check ('vllm' or 'api-endpoint')"
-    )
+        None, "--provider", help="Provider to check (defaults to config setting)"
+    ),
 ):
-    """
-    Check if the selected LLM provider's server is running.
-    """
-    # Check for API_ENDPOINT_KEY directly from environment
-    console.print("Environment variable check:", style="bold blue")
-    llama_key = os.environ.get('API_ENDPOINT_KEY')
-    console.print(f"API_ENDPOINT_KEY: {'Present' if llama_key else 'Not found'}")
-    # Debugging sanity test:
-    # if llama_key:
-        # console.print(f"  Value starts with: {llama_key[:10]}...")
-    
-    # To check the rename bug:
-    #console.print("Available environment variables:", style="bold blue")
-    #env_vars = [key for key in os.environ.keys() if 'API' in key or 'KEY' in key or 'TOKEN' in key]
-    #for var in env_vars:
-    #    console.print(f"  {var}")
-    #console.print("")
-    # Get provider from args or config
+    """Check if the selected LLM provider's server is running."""
     selected_provider = provider or get_llm_provider(ctx.config)
-    
-    if selected_provider == "api-endpoint":
-        # Get API endpoint config
-        api_endpoint_config = get_openai_config(ctx.config)
-        api_base = api_base or api_endpoint_config.get("api_base")
-        
-        # Check for environment variables
-        api_endpoint_key = os.environ.get('API_ENDPOINT_KEY')
-        console.print(f"API_ENDPOINT_KEY environment variable: {'Found' if api_endpoint_key else 'Not found'}")
-        
-        # Set API key with priority: env var > config
-        api_key = api_endpoint_key or api_endpoint_config.get("api_key")
-        if api_key:
-            console.print(f"API key source: {'Environment variable' if api_endpoint_key else 'Config file'}")
-        
-        model = api_endpoint_config.get("model")
-        
-        # Check API endpoint access
-        with console.status(f"Checking API endpoint access..."):
+
+    if selected_provider != "openai-endpoint":
+        # TODO: Remove once other providers are supported
+        console.print(
+            f"⚠️  System check for provider '{selected_provider}' is not implemented yet.",
+            style="yellow",
+        )
+        return 1
+
+    provider_config = get_provider_config(ctx.config, selected_provider)
+
+    env_keys = ["API_ENDPOINT_KEY", "OPENAI_API_KEY"]
+    console.print("Environment variable check:", style="bold blue")
+    for key in env_keys:
+        console.print(f"{key}: {'Present' if os.environ.get(key) else 'Not found'}")
+
+    env_api_key = next((os.environ.get(key) for key in env_keys if os.environ.get(key)), None)
+
+    api_key = env_api_key or provider_config.get("api_key")
+    if api_key:
+        console.print(f"API key source: {'Environment variable' if env_api_key else 'Config file'}")
+
+    resolved_api_base = api_base or provider_config.get("api_base")
+    models_path = provider_config.get("models_path", "/models")
+    if not models_path.startswith("/"):
+        models_path = f"/{models_path}"
+    models_url = f"{resolved_api_base.rstrip('/')}{models_path}"
+
+    console.print(f"Checking {selected_provider} at {models_url}...", style="blue")
+
+    model = provider_config.get("model")
+    # Check API endpoint access
+    with console.status(f"Checking API endpoint access..."):
+        try:
+            # Try to import OpenAI
             try:
-                # Try to import OpenAI
-                try:
-                    from openai import OpenAI
-                except ImportError:
-                    console.print("L API endpoint package not installed", style="red")
-                    console.print("Install with: pip install openai>=1.0.0", style="yellow")
-                    return 1
-                
-                # Create client
-                client_kwargs = {}
-                if api_key:
-                    client_kwargs['api_key'] = api_key
-                if api_base:
-                    client_kwargs['base_url'] = api_base
-                
-                # Check API access
-                try:
-                    client = OpenAI(**client_kwargs)
-                    # Try a simple models request to check connectivity
-                    messages = [
-                        {"role": "user", "content": "Hello"}
-                    ]
-                    response = client.chat.completions.create(
-                        model=model,
-                        messages=messages, 
-                        temperature=0.1
-                    )
-                    console.print(f" API endpoint access confirmed", style="green")
-                    if api_base:
-                        console.print(f"Using custom API base: {api_base}", style="green")
-                    console.print(f"Default model: {model}", style="green")
-                    console.print(f"Response from model: {response.choices[0].message.content}", style="green")
-                    return 0
-                except Exception as e:
-                    console.print(f"L Error connecting to API endpoint: {str(e)}", style="red")
-                    if api_base:
-                        console.print(f"Using custom API base: {api_base}", style="yellow")
-                    if not api_key and not api_base:
-                        console.print("API key is required. Set in config.yaml or as API_ENDPOINT_KEY env var", style="yellow")
-                    return 1
-            except Exception as e:
-                console.print(f"L Error: {str(e)}", style="red")
+                from openai import OpenAI
+            except ImportError:
+                console.print("L API endpoint package not installed", style="red")
+                console.print("Install with: pip install openai>=1.0.0", style="yellow")
                 return 1
-    else:
-        # Default to vLLM
-        # Get vLLM server details
-        vllm_config = get_vllm_config(ctx.config)
-        api_base = api_base or vllm_config.get("api_base")
-        model = vllm_config.get("model")
-        port = vllm_config.get("port", 8000)
-        
-        with console.status(f"Checking vLLM server at {api_base}..."):
+            
+            # Create client
+            client_kwargs = {}
+            if api_key:
+                client_kwargs['api_key'] = api_key
+            if resolved_api_base:
+                client_kwargs['base_url'] = resolved_api_base
+            
+            # Check API access
             try:
-                response = requests.get(f"{api_base}/models", timeout=2)
-                if response.status_code == 200:
-                    console.print(f" vLLM server is running at {api_base}", style="green")
-                    console.print(f"Available models: {response.json()}")
-                    return 0
-                else:
-                    console.print(f"L vLLM server is not available at {api_base}", style="red")
-                    console.print(f"Error: Server returned status code: {response.status_code}")
-            except requests.exceptions.RequestException as e:
-                console.print(f"L vLLM server is not available at {api_base}", style="red")
-                console.print(f"Error: {str(e)}")
-                
-            # Show instruction to start the server
-            console.print("\nTo start the server, run:", style="yellow")
-            console.print(f"vllm serve {model} --port {port}", style="bold blue")
+                client = OpenAI(**client_kwargs)
+                # Try a simple models request to check connectivity
+                messages = [
+                    {"role": "user", "content": "Hello"}
+                ]
+                response = client.chat.completions.create(
+                    model=model,
+                    messages=messages, 
+                    temperature=0.1
+                )
+                console.print(f" API endpoint access confirmed", style="green")
+                if api_base:
+                    console.print(f"Using custom API base: {api_base}", style="green")
+                console.print(f"Default model: {model}", style="green")
+                console.print(f"Response from model: {response.choices[0].message.content}", style="green")
+                return 0
+            except Exception as e:
+                console.print(f"L Error connecting to API endpoint: {str(e)}", style="red")
+                if api_base:
+                    console.print(f"Using custom API base: {api_base}", style="yellow")
+                if not api_key and not api_base:
+                    console.print("API key is required. Set in config.yaml or as API_ENDPOINT_KEY env var", style="yellow")
+                return 1
+        except Exception as e:
+            console.print(f"L Error: {str(e)}", style="red")
             return 1
+
 
 
 @app.command()
@@ -324,40 +297,27 @@ def create(
        - An array of conversation objects, each with a 'conversations' field
        - A direct array of conversation messages)
     """
-    import os
     from synthetic_data_kit.core.create import process_file
     from synthetic_data_kit.utils.directory_processor import is_directory, process_directory_create, get_directory_stats, CREATE_EXTENSIONS
     
-    # Check the LLM provider from config
     provider = get_llm_provider(ctx.config)
     console.print(f"🔗 Using {provider} provider", style="green")
-    
-    if provider == "api-endpoint":
-        # Use API endpoint config
-        api_endpoint_config = get_openai_config(ctx.config)
-        api_base = api_base or api_endpoint_config.get("api_base")
-        model = model or api_endpoint_config.get("model")
-        # No server check needed for API endpoint
-    else:
-        # Use vLLM config
-        vllm_config = get_vllm_config(ctx.config)
-        api_base = api_base or vllm_config.get("api_base")
-        model = model or vllm_config.get("model")
-        
-        # Check vLLM server availability
-        try:
-            response = requests.get(f"{api_base}/models", timeout=2)
-            if response.status_code != 200:
-                console.print(f"❌ Error: VLLM server not available at {api_base}", style="red")
-                console.print("Please start the VLLM server with:", style="yellow")
-                console.print(f"vllm serve {model}", style="bold blue")
-                return 1
-        except requests.exceptions.RequestException:
-            console.print(f"❌ Error: VLLM server not available at {api_base}", style="red")
-            console.print("Please start the VLLM server with:", style="yellow")
-            console.print(f"vllm serve {model}", style="bold blue")
-            return 1
-    
+
+    provider_config = get_provider_config(ctx.config, provider)
+
+    api_base = api_base or provider_config.get("api_base")
+    if not api_base:
+        console.print(
+            "❌ API base URL is not configured. Set it in config or provide --api-base.",
+            style="red",
+        )
+        return 1
+
+    model = model or provider_config.get("model")
+    if not model:
+        console.print("❌ No model configured for this provider.", style="red")
+        return 1
+
     # Get output directory from args, then config, then default
     if output_dir is None:
         output_dir = get_path_config(ctx.config, "output", "generated")
@@ -489,35 +449,24 @@ def curate(
     
     # Check the LLM provider from config
     provider = get_llm_provider(ctx.config)
-    
+
     console.print(f"🔗 Using {provider} provider", style="green")
-    
-    if provider == "api-endpoint":
-        # Use API endpoint config
-        api_endpoint_config = get_openai_config(ctx.config)
-        api_base = api_base or api_endpoint_config.get("api_base")
-        model = model or api_endpoint_config.get("model")
-        # No server check needed for API endpoint
-    else:
-        # Use vLLM config
-        vllm_config = get_vllm_config(ctx.config)
-        api_base = api_base or vllm_config.get("api_base")
-        model = model or vllm_config.get("model")
-        
-        # Check vLLM server availability
-        try:
-            response = requests.get(f"{api_base}/models", timeout=2)
-            if response.status_code != 200:
-                console.print(f"❌ Error: VLLM server not available at {api_base}", style="red")
-                console.print("Please start the VLLM server with:", style="yellow")
-                console.print(f"vllm serve {model}", style="bold blue")
-                return 1
-        except requests.exceptions.RequestException:
-            console.print(f"❌ Error: VLLM server not available at {api_base}", style="red")
-            console.print("Please start the VLLM server with:", style="yellow")
-            console.print(f"vllm serve {model}", style="bold blue")
-            return 1
-    
+
+    provider_config = get_provider_config(ctx.config, provider)
+
+    api_base = api_base or provider_config.get("api_base")
+    if not api_base:
+        console.print(
+            "❌ API base URL is not configured. Set it in config or provide --api-base.",
+            style="red",
+        )
+        return 1
+
+    model = model or provider_config.get("model")
+    if not model:
+        console.print("❌ No model configured for this provider.", style="red")
+        return 1
+
     try:
         # Check if input is a directory
         if is_directory(input):

--- a/synthetic_data_kit/config.yaml
+++ b/synthetic_data_kit/config.yaml
@@ -14,24 +14,20 @@ paths:
 
 # LLM Provider configuration
 llm:
-  # Provider selection: "vllm" or "api-endpoint"
-  provider: "api-endpoint"
+  # Provider selection: "openai-endpoint" (OpenAI-compatible APIs)
+  provider: "openai-endpoint"
 
-# VLLM server configuration
-vllm:
-  api_base: "http://localhost:8000/v1" # Base URL for VLLM API
-  port: 8000                           # Port for VLLM server
-  model: "meta-llama/Llama-3.3-70B-Instruct" # Default model to use
-  max_retries: 3                       # Number of retries for API calls
-  retry_delay: 1.0                     # Initial delay between retries (seconds)
-  
-# API endpoint configuration
-api-endpoint:
-  api_base: "https://api.llama.com/v1" # Optional base URL for API endpoint (null for default API)
-  api_key: "llama-api-key"               # API key for API endpoint or compatible service (can use env var instead)
+
+# OpenAI-compatible endpoint configuration
+openai-endpoint:
+  api_base: "https://api.llama.com/v1"    # Base URL for OpenAI-compatible API
+  api_key: "llama-api-key"                # API key for the endpoint (can also use env vars)
   model: "Llama-4-Maverick-17B-128E-Instruct-FP8" # Default model to use
-  max_retries: 3                       # Number of retries for API calls
-  retry_delay: 1.0                     # Initial delay between retries (seconds)
+  max_retries: 3                          # Number of retries for API calls
+  retry_delay: 1.0                        # Initial delay between retries (seconds)
+  sleep_time: 0.5                         # Pause between batch chunks (seconds)
+  http_request_timeout: 300               # Timeout for HTTP requests (seconds)
+  max_concurrent_requests: 32             # Maximum concurrent requests during batching
 
 # Ingest configuration
 ingest:

--- a/synthetic_data_kit/core/context.py
+++ b/synthetic_data_kit/core/context.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 import os
 
-from synthetic_data_kit.utils.config import DEFAULT_CONFIG_PATH, load_config, get_path_config
+from synthetic_data_kit.utils.config import DEFAULT_CONFIG_PATH, load_config
 
 class AppContext:
     """Context manager for global app state"""
@@ -45,3 +45,9 @@ class AppContext:
         
         for dir_path in output_dirs:
             os.makedirs(dir_path, exist_ok=True)
+
+
+    def update_config(self, new_config: Dict[str, Any]) -> None:
+        """Replace configuration at runtime (primarily for testing)."""
+        self.config = new_config
+        self._ensure_data_dirs()

--- a/synthetic_data_kit/core/create.py
+++ b/synthetic_data_kit/core/create.py
@@ -81,6 +81,8 @@ def process_file(
     # Generate content based on type
     if file_path.endswith(".lance"):
         dataset = load_lance_dataset(file_path)
+        if not dataset:
+            raise ValueError(f"Failed to load Lance dataset from {file_path}")
         documents = dataset.to_table().to_pylist()
     else:
         documents = [{"text": read_json(file_path), "image": None}]

--- a/synthetic_data_kit/models/base.py
+++ b/synthetic_data_kit/models/base.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+import logging
+import os
+from typing import Any, Dict, List
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class BaseLLMProvider:
+    """Abstract base class for all LLM providers."""
+
+    def __init__(self, name: str, config: Dict[str, Any], overrides: Dict[str, Any]):
+        self.name = name
+        self.config = config
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
+
+        model_override = overrides.get("model_name")
+        self.model = model_override or config.get("model")
+        if not self.model:
+            raise ValueError(f"Model must be specified for provider '{name}'")
+
+        self.max_retries = overrides.get("max_retries") or config.get("max_retries", 3)
+        self.retry_delay = overrides.get("retry_delay") or config.get("retry_delay", 1.0)
+        self.sleep_time = config.get("sleep_time", 0.5)
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> str:
+        raise NotImplementedError
+
+    def batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        batch_size: int,
+        verbose: bool,
+    ) -> List[str]:
+        raise NotImplementedError

--- a/synthetic_data_kit/models/example_provider.py
+++ b/synthetic_data_kit/models/example_provider.py
@@ -1,0 +1,336 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+import asyncio
+import os
+import threading
+import time
+from typing import Any, Dict, List
+
+import aiohttp
+import requests
+
+from synthetic_data_kit.models.base import BaseLLMProvider
+
+
+"""
+This is just supposed to serve as an example of how to implement a new provider which
+does not provide a dedicated client library and we instead have to use HTTP requests directly.
+"""
+class ExampleHTTPProvider(BaseLLMProvider):
+    """Example provider using raw HTTP transport for OpenAI-compatible endpoints."""
+
+    def __init__(self, config: Dict[str, Any], overrides: Dict[str, Any]):
+        super().__init__("openai-http", config, overrides)
+
+        self.api_base = (
+            overrides.get("api_base")
+            or config.get("api_base")
+        )
+
+        env_keys = config.get("api_key_env_vars", ["API_ENDPOINT_KEY", "OPENAI_API_KEY"])
+        env_api_key = None
+        for key in env_keys:
+            value = os.environ.get(key)
+            if value:
+                env_api_key = value
+                break
+
+        self.api_key = overrides.get("api_key") or env_api_key or config.get("api_key")
+        self.api_key_header = config.get("api_key_header", "Authorization")
+        self.api_key_scheme = config.get("api_key_scheme", "Bearer")
+        self.require_api_key = config.get("require_api_key", False)
+
+        self.headers: Dict[str, str] = {"Content-Type": "application/json"}
+        additional_headers = config.get("headers", {})
+        if isinstance(additional_headers, dict):
+            self.headers.update({str(k): str(v) for k, v in additional_headers.items()})
+
+        if self.api_key:
+            self._apply_api_key_header(self.headers)
+        elif self.require_api_key:
+            raise ValueError(
+                "API key is required for openai-endpoint provider. Set it in config or via environment variables."
+            )
+
+        query_params = config.get("query_params", {})
+        self.query_params = dict(query_params) if isinstance(query_params, dict) else {}
+
+        payload_overrides = config.get("payload_overrides", {})
+        self.payload_overrides = (
+            dict(payload_overrides) if isinstance(payload_overrides, dict) else {}
+        )
+
+        self.http_request_timeout = (
+            overrides.get("http_request_timeout") or config.get("http_request_timeout", 300)
+        )
+
+        self.max_concurrent_requests = config.get("max_concurrent_requests", 32) or 32
+
+        endpoint_path = config.get("endpoint_path", "/chat/completions").format(model=self.model)
+        if not endpoint_path.startswith("/"):
+            endpoint_path = f"/{endpoint_path}"
+        self.chat_url = f"{self.api_base.rstrip('/')}{endpoint_path}"
+        self.models_url = f"{self.api_base.rstrip('/')}/models"
+
+    def _apply_api_key_header(self, headers: Dict[str, str]) -> None:
+        header_name = (self.api_key_header or "Authorization").strip()
+        if header_name.lower() == "authorization":
+            scheme = (self.api_key_scheme or "Bearer").strip()
+            if scheme:
+                headers["Authorization"] = f"{scheme} {self.api_key}"
+            else:
+                headers["Authorization"] = str(self.api_key)
+        else:
+            headers[header_name] = str(self.api_key)
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> str:
+        payload = self._build_payload(messages, temperature, max_tokens, top_p)
+        debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
+
+        for attempt in range(self.max_retries):
+            try:
+                if verbose and attempt == 0:
+                    self.logger.info(
+                        "Sending request to %s model %s...", self.name, self.model
+                    )
+
+                response = requests.post(
+                    self.chat_url,
+                    headers=self.headers,
+                    params=self.query_params,
+                    json=payload,
+                    timeout=self.http_request_timeout,
+                )
+
+                if verbose:
+                    self.logger.info(
+                        "Received response with status code: %s", response.status_code
+                    )
+
+                response.raise_for_status()
+                response_json = response.json()
+
+                if debug_mode:
+                    self.logger.debug("Raw response: %s", response_json)
+                    
+                return response_json["choices"][0]["message"]["content"]
+
+            except (requests.exceptions.RequestException, ValueError, KeyError) as exc:
+                error_message = str(exc)
+                if verbose:
+                    self.logger.warning(
+                        "%s API error (attempt %s/%s): %s",
+                        self.name,
+                        attempt + 1,
+                        self.max_retries,
+                        error_message,
+                    )
+
+                if attempt == self.max_retries - 1:
+                    raise Exception(
+                        f"Failed to get {self.name} completion after {self.max_retries} attempts: {error_message}"
+                    ) from exc
+
+                time.sleep(self.retry_delay * (attempt + 1))
+
+        raise RuntimeError("Exceeded retry attempts without raising")
+
+    def batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        batch_size: int,
+        verbose: bool,
+    ) -> List[str]:
+        if not message_batches:
+            return []
+
+        batch_size = max(1, batch_size)
+        total_batches = (len(message_batches) + batch_size - 1) // batch_size
+        results: List[str] = []
+
+        for index in range(0, len(message_batches), batch_size):
+            batch_chunk = message_batches[index:index + batch_size]
+            batch_number = index // batch_size + 1
+
+            if verbose:
+                self.logger.info(
+                    "Processing batch %s/%s with %s requests",
+                    batch_number,
+                    total_batches,
+                    len(batch_chunk),
+                )
+
+            chunk_results = self._run_coroutine(
+                self._process_batch_async(batch_chunk, temperature, max_tokens, top_p, verbose)
+            )
+            results.extend(chunk_results)
+
+            if index + batch_size < len(message_batches):
+                time.sleep(self.sleep_time)
+
+        return results
+
+    def _build_payload(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "top_p": top_p,
+        }
+        if self.payload_overrides:
+            payload.update(self.payload_overrides)
+        return payload
+
+    async def _process_batch_async(
+        self,
+        batch_chunk: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> List[str]:
+        if not batch_chunk:
+            return []
+
+        max_concurrent = self.max_concurrent_requests or len(batch_chunk)
+        max_concurrent = max(1, min(max_concurrent, len(batch_chunk)))
+
+        # Create semaphore to limit concurrent connections (prevent overwhelming the server)
+        connector = aiohttp.TCPConnector(
+            limit=max_concurrent * 2,
+            limit_per_host=max_concurrent,
+            ttl_dns_cache=300,
+            use_dns_cache=True,
+        )
+        timeout = aiohttp.ClientTimeout(total=self.http_request_timeout)
+
+        async with aiohttp.ClientSession(
+            connector=connector,
+            timeout=timeout,
+            headers=dict(self.headers),
+        ) as session:
+            semaphore = asyncio.Semaphore(max_concurrent)
+            tasks = [
+                self._process_single_request(
+                    session,
+                    messages,
+                    semaphore,
+                    temperature,
+                    max_tokens,
+                    top_p,
+                    verbose,
+                )
+                for messages in batch_chunk
+            ]
+            return await asyncio.gather(*tasks, return_exceptions=False)
+
+    async def _process_single_request(
+        self,
+        session: aiohttp.ClientSession,
+        messages: List[Dict[str, str]],
+        semaphore: asyncio.Semaphore,
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> str:
+        payload = self._build_payload(messages, temperature, max_tokens, top_p)
+        debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
+
+        for attempt in range(self.max_retries):
+            try:
+                async with semaphore:  # Limit concurrent requests
+                    if verbose and attempt == 0:
+                        self.logger.info(
+                            "Sending async request to %s model %s...", self.name, self.model
+                        )
+
+                    async with session.post(
+                        self.chat_url,
+                        params=self.query_params,
+                        json=payload,
+                    ) as response:
+                        if verbose and attempt == 0:
+                            self.logger.info(
+                                "Received response with status code: %s", response.status
+                            )
+
+                        response.raise_for_status()
+                        response_json = await response.json()
+
+                        if debug_mode:
+                            self.logger.debug("Raw async response: %s", response_json)
+
+                        return response_json["choices"][0]["message"]["content"]
+
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, KeyError) as exc:
+                error_message = f"{type(exc).__name__}: {exc}"
+                if attempt == self.max_retries - 1:
+                    if verbose:
+                        self.logger.warning(
+                            "%s async request failed after %s attempts: %s",
+                            self.name,
+                            self.max_retries,
+                            error_message,
+                        )
+                    return f"ERROR: {error_message}"
+
+                await asyncio.sleep(self.retry_delay * (attempt + 1))
+
+        return "ERROR: exceeded retry attempts"
+
+    def _run_coroutine(self, coroutine: asyncio.Future) -> Any:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            return self._run_coroutine_in_thread(coroutine)
+
+        return asyncio.run(coroutine)
+
+    def _run_coroutine_in_thread(self, coroutine: asyncio.Future) -> Any:
+        result_container: Dict[str, Any] = {}
+
+        def runner() -> None:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                result_container["result"] = new_loop.run_until_complete(coroutine)
+            except Exception as exc:
+                result_container["error"] = exc
+            finally:
+                new_loop.run_until_complete(new_loop.shutdown_asyncgens())
+                new_loop.close()
+                asyncio.set_event_loop(None)
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        thread.join()
+
+        if "error" in result_container:
+            raise result_container["error"]
+
+        return result_container.get("result", [])
+

--- a/synthetic_data_kit/models/example_provider.py
+++ b/synthetic_data_kit/models/example_provider.py
@@ -41,7 +41,6 @@ class ExampleHTTPProvider(BaseLLMProvider):
         self.api_key = overrides.get("api_key") or env_api_key or config.get("api_key")
         self.api_key_header = config.get("api_key_header", "Authorization")
         self.api_key_scheme = config.get("api_key_scheme", "Bearer")
-        self.require_api_key = config.get("require_api_key", False)
 
         self.headers: Dict[str, str] = {"Content-Type": "application/json"}
         additional_headers = config.get("headers", {})
@@ -50,10 +49,7 @@ class ExampleHTTPProvider(BaseLLMProvider):
 
         if self.api_key:
             self._apply_api_key_header(self.headers)
-        elif self.require_api_key:
-            raise ValueError(
-                "API key is required for openai-endpoint provider. Set it in config or via environment variables."
-            )
+
 
         query_params = config.get("query_params", {})
         self.query_params = dict(query_params) if isinstance(query_params, dict) else {}

--- a/synthetic_data_kit/models/llm_client.py
+++ b/synthetic_data_kit/models/llm_client.py
@@ -3,669 +3,123 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-# Supports both vLLM and API endpoint (including OpenAI-compatible) providers
-from typing import List, Dict, Any, Optional, Union, Tuple
-import requests
-import json
-import time
-import os
+from typing import List, Dict, Any, Optional
 import logging
-import asyncio
-import aiohttp
-from pathlib import Path
+import os
 
-from synthetic_data_kit.utils.config import load_config, get_vllm_config, get_openai_config, get_llm_provider
+from synthetic_data_kit.models.base import BaseLLMProvider
+from synthetic_data_kit.models.openai_provider import OpenAIEndpointProvider
+from synthetic_data_kit.utils.config import (
+    load_config,
+    get_llm_provider,
+    get_provider_config,
+)
 
-# Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Try to import OpenAI, but handle case where it's not installed
-try:
-    from openai import OpenAI
-    from openai.types.chat import ChatCompletion
-    OPENAI_AVAILABLE = True
-except ImportError:
-    OPENAI_AVAILABLE = False
-    logger.warning("OpenAI package not installed. To use API endpoint provider, install with 'pip install openai>=1.0.0'")
 
 class LLMClient:
-    def __init__(self, 
-                 config_path: Optional[Path] = None,
-                 provider: Optional[str] = None,
-                 api_base: Optional[str] = None, 
-                 api_key: Optional[str] = None,
-                 model_name: Optional[str] = None,
-                 max_retries: Optional[int] = None,
-                 retry_delay: Optional[float] = None,
-                 http_request_timeout: Optional[int] = None):
-        """Initialize an LLM client that supports multiple providers
-        
-        Args:
-            config_path: Path to config file (if None, uses default)
-            provider: Override provider from config ('vllm' or 'api-endpoint')
-            api_base: Override API base URL from config
-            api_key: Override API key for API endpoint (only needed for 'api-endpoint' provider)
-            model_name: Override model name from config
-            max_retries: Override max retries from config
-            retry_delay: Override retry delay from config
-        """
-        # Load config
-        self.config = load_config(config_path)
-        
-        # Determine provider (with CLI override taking precedence)
-        self.provider = provider or get_llm_provider(self.config)
-        
-        if self.provider == 'api-endpoint':
-            if not OPENAI_AVAILABLE:
-                raise ImportError("OpenAI package is not installed. Install with 'pip install openai>=1.0.0'")
-            
-            # Load API endpoint configuration
-            api_endpoint_config = get_openai_config(self.config)
-            
-            # Set parameters, with CLI overrides taking precedence
-            self.api_base = api_base or api_endpoint_config.get('api_base')
-            
-            # Check for environment variables
-            api_endpoint_key = os.environ.get('API_ENDPOINT_KEY')
-            print(f"API_ENDPOINT_KEY from environment: {'Found' if api_endpoint_key else 'Not found'}")
-            
-            # Set API key with priority: CLI arg > env var > config
-            self.api_key = api_key or api_endpoint_key or api_endpoint_config.get('api_key')
-            print(f"Using API key: {'From CLI' if api_key else 'From env var' if api_endpoint_key else 'From config' if api_endpoint_config.get('api_key') else 'None'}")
-            
-            if not self.api_key and not self.api_base:  # Only require API key for official API
-                raise ValueError("API key is required for API endpoint provider. Set in config or API_ENDPOINT_KEY env var.")
-            
-            self.model = model_name or api_endpoint_config.get('model')
-            self.max_retries = max_retries or api_endpoint_config.get('max_retries')
-            self.retry_delay = retry_delay or api_endpoint_config.get('retry_delay')
-            self.sleep_time = api_endpoint_config.get('sleep_time',0.5)
-            
-            # Initialize OpenAI client
-            self._init_openai_client()
-        else:  # Default to vLLM
-            # Load vLLM configuration
-            vllm_config = get_vllm_config(self.config)
-            
-            # Set parameters, with CLI overrides taking precedence
-            self.api_base = api_base or vllm_config.get('api_base')
-            self.model = model_name or vllm_config.get('model')
-            self.max_retries = max_retries or vllm_config.get('max_retries')
-            self.retry_delay = retry_delay or vllm_config.get('retry_delay')
-            self.sleep_time = vllm_config.get('sleep_time',0.1)
-            self.http_request_timeout = vllm_config.get('http_request_timeout', 180)
-            
-            # No client to initialize for vLLM as we use requests directly
-            # Verify server is running
-            available, info = self._check_vllm_server()
-            if not available:
-                raise ConnectionError(f"VLLM server not available at {self.api_base}: {info}")
-    
-    def _init_openai_client(self):
-        """Initialize OpenAI client with appropriate configuration"""
-        client_kwargs = {}
-        
-        # Add API key if provided
-        if self.api_key:
-            # Print first few characters of the API key for debugging
-            #print(f"Using API key (first 10 chars): {self.api_key[:10]}...")
-            client_kwargs['api_key'] = self.api_key
-        else:
-            print("No API key found!")
-        
-        # Add base URL if provided (for OpenAI-compatible APIs)
-        if self.api_base:
-            print(f"Using API base URL: {self.api_base}")
-            client_kwargs['base_url'] = self.api_base
-        
-        self.openai_client = OpenAI(**client_kwargs)
-    
-    def _check_vllm_server(self) -> tuple:
-        """Check if the VLLM server is running and accessible"""
-        try:
-            response = requests.get(f"{self.api_base}/models", timeout=5)
-            if response.status_code == 200:
-                return True, response.json()
-            return False, f"Server returned status code: {response.status_code}"
-        except requests.exceptions.RequestException as e:
-            return False, f"Server connection error: {str(e)}"
-    
-    def chat_completion(self, 
-                      messages: List[Dict[str, str]], 
-                      temperature: float = None, 
-                      max_tokens: int = None,
-                      top_p: float = None) -> str:
-        """Generate a chat completion using the selected provider
-        
-        Args:
-            messages: List of message dictionaries with 'role' and 'content'
-            temperature: Sampling temperature (higher = more random)
-            max_tokens: Maximum tokens to generate
-            top_p: Nucleus sampling parameter
-            
-        Returns:
-            String containing the generated text
-        """
-        # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
-        if self.provider == 'api-endpoint':
-            return self._openai_chat_completion(messages, temperature, max_tokens, top_p, verbose)
-        else:  # Default to vLLM
-            return self._vllm_chat_completion(messages, temperature, max_tokens, top_p, verbose)
-    
-    def _openai_chat_completion(self, 
-                              messages: List[Dict[str, str]],
-                              temperature: float,
-                              max_tokens: int,
-                              top_p: float,
-                              verbose: bool) -> str:
-        """Generate a chat completion using the OpenAI API or compatible APIs"""
-        debug_mode = os.environ.get('SDK_DEBUG', 'false').lower() == 'true'
-        if verbose:
-            logger.info(f"Sending request to {self.provider} model {self.model}...")
-            
-        for attempt in range(self.max_retries):
-            try:
-                # Create the completion request
-                response = self.openai_client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    top_p=top_p
-                )
-                
-                if verbose:
-                    logger.info(f"Received response from {self.provider}")
-                
-                # Log the full response in debug mode
-                if debug_mode:
-                    if hasattr(response, 'model_dump'):
-                        logger.debug(f"Full response: {response.model_dump()}")
-                    else:
-                        logger.debug(f"Response type: {type(response)}")
-                        logger.debug(f"Response attributes: {dir(response)}")
-                
-                # Method 1: Try standard OpenAI API response format
-                try:
-                    if hasattr(response, 'choices') and response.choices is not None and len(response.choices) > 0:
-                        choice = response.choices[0]
-                        if hasattr(choice, 'message') and choice.message is not None:
-                            if hasattr(choice.message, 'content') and choice.message.content is not None:
-                                return choice.message.content
-                except Exception as e:
-                    if verbose:
-                        logger.info(f"Standard format extraction failed: {e}, trying alternative formats...")
-                
-                # Method 2: Llama API format
-                try:
-                    if hasattr(response, 'completion_message') and response.completion_message is not None:
-                        completion = response.completion_message
-                        # Handle dictionary case
-                        if isinstance(completion, dict) and 'content' in completion:
-                            content = completion['content']
-                            # Different Llama API response formats
-                            if isinstance(content, dict) and 'text' in content:
-                                return content['text']
-                            elif isinstance(content, str):
-                                return content
-                except Exception as e:
-                    if verbose:
-                        logger.info(f"Llama API format extraction failed: {e}, trying dictionary access...")
-                
-                # Method 3: Try dictionary access for both formats
-                try:
-                    # Convert to dictionary if possible
-                    response_dict = None
-                    if hasattr(response, 'model_dump'):
-                        response_dict = response.model_dump()
-                    elif hasattr(response, 'dict'):
-                        response_dict = response.dict()
-                    elif hasattr(response, '__dict__'):
-                        response_dict = response.__dict__
-                    elif isinstance(response, dict):
-                        response_dict = response
-                    
-                    if response_dict is not None:
-                        # Try Llama API format
-                        if 'completion_message' in response_dict and response_dict['completion_message'] is not None:
-                            comp = response_dict['completion_message']
-                            if isinstance(comp, dict) and 'content' in comp:
-                                content = comp['content']
-                                if isinstance(content, dict) and 'text' in content:
-                                    return content['text']
-                                elif isinstance(content, str):
-                                    return content
-                        
-                        # Try OpenAI format
-                        if 'choices' in response_dict and response_dict['choices'] is not None and len(response_dict['choices']) > 0:
-                            choice = response_dict['choices'][0]
-                            if isinstance(choice, dict) and 'message' in choice:
-                                message = choice['message']
-                                if isinstance(message, dict) and 'content' in message and message['content'] is not None:
-                                    return message['content']
-                except Exception as e:
-                    if verbose:
-                        logger.info(f"Dictionary access failed: {e}")
-                
-                # Last resort: Try to print the full response for debugging
-                if verbose or debug_mode:
-                    logger.error("Could not extract content from response using any known method")
-                    logger.error(f"Response: {response}")
-                    if isinstance(response, dict):
-                        for k, v in response.items():
-                            logger.error(f"Key: {k}, Value type: {type(v)}, Value: {v}")
-                    # Try to find any content-like fields
-                    all_attrs = dir(response)
-                    content_fields = [attr for attr in all_attrs if 'content' in attr.lower() or 'text' in attr.lower() or 'message' in attr.lower()]
-                    for field in content_fields:
-                        try:
-                            logger.error(f"Potential content field '{field}': {getattr(response, field, 'N/A')}")
-                        except:
-                            pass
-                
-                raise ValueError(f"Could not extract content from response using any known method")
-                
-            except Exception as e:
-                if verbose:
-                    logger.error(f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}")
-                
-                if attempt == self.max_retries - 1:
-                    raise Exception(f"Failed to get {self.provider} completion after {self.max_retries} attempts: {str(e)}")
-                
-                time.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def _vllm_chat_completion(self, 
-                            messages: List[Dict[str, str]],
-                            temperature: float,
-                            max_tokens: int,
-                            top_p: float,
-                            verbose: bool) -> str:
-        """Generate a chat completion using the VLLM OpenAI-compatible API"""
-        data = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p
-        }
-        
-        for attempt in range(self.max_retries):
-            try:
-                # Only print if verbose mode is enabled
-                if verbose:
-                    logger.info(f"Sending request to vLLM model {self.model}...")
-                
-                response = requests.post(
-                    f"{self.api_base}/chat/completions",
-                    headers={"Content-Type": "application/json"},
-                    data=json.dumps(data),
-                    timeout=self.http_request_timeout  # made the http timeout dynamic
-                )
-                
-                if verbose:
-                    logger.info(f"Received response with status code: {response.status_code}")
-                
-                response.raise_for_status()
-                return response.json()["choices"][0]["message"]["content"]
-            
-            except (requests.exceptions.RequestException, KeyError, IndexError) as e:
-                if attempt == self.max_retries - 1:
-                    raise Exception(f"Failed to get vLLM completion after {self.max_retries} attempts: {str(e)}")
-                time.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def batch_completion(self, 
-                       message_batches: List[List[Dict[str, str]]], 
-                       temperature: float = None, 
-                       max_tokens: int = None,
-                       top_p: float = None,
-                       batch_size: int = None) -> List[str]:
-        """Process multiple message sets in batches
-        
-        Instead of sending requests one at a time, this method processes
-        multiple prompts in batches to maximize throughput.
-        """
-        # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        batch_size = batch_size if batch_size is not None else generation_config.get('batch_size', 32)
-        
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
-        if self.provider == 'api-endpoint':
-            return self._openai_batch_completion(message_batches, temperature, max_tokens, top_p, batch_size, verbose)
-        else:  # Default to vLLM
-            return self._vllm_batch_completion(message_batches, temperature, max_tokens, top_p, batch_size, verbose)
-    
-    async def _process_message_async(self, 
-                                    messages: List[Dict[str, str]], 
-                                    temperature: float,
-                                    max_tokens: int,
-                                    top_p: float,
-                                    verbose: bool,
-                                    debug_mode: bool):
-        """Process a single message set asynchronously using the OpenAI API"""
-        try:
-            from openai import AsyncOpenAI
-        except ImportError:
-            raise ImportError("The 'openai' package is required for this functionality. Please install it using 'pip install openai>=1.0.0'.")
-        
-        # Initialize the async OpenAI client
-        client_kwargs = {}
-        if self.api_key:
-            client_kwargs['api_key'] = self.api_key
-        if self.api_base:
-            client_kwargs['base_url'] = self.api_base
-            
-        async_client = AsyncOpenAI(**client_kwargs)
-        
-        for attempt in range(self.max_retries):
-            try:
-                # Asynchronously call the API
-                response = await async_client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    top_p=top_p
-                )
-                
-                if verbose:
-                    logger.info(f"Received response from {self.provider}")
-                
-                # Log the full response in debug mode
-                if debug_mode:
-                    if hasattr(response, 'model_dump'):
-                        logger.debug(f"Full response: {response.model_dump()}")
-                    else:
-                        logger.debug(f"Response type: {type(response)}")
-                        logger.debug(f"Response attributes: {dir(response)}")
-                
-                content = None
-                
-                # Method 1: Try standard OpenAI API response format
-                try:
-                    if hasattr(response, 'choices') and response.choices is not None and len(response.choices) > 0:
-                        choice = response.choices[0]
-                        if hasattr(choice, 'message') and choice.message is not None:
-                            if hasattr(choice.message, 'content') and choice.message.content is not None:
-                                content = choice.message.content
-                except Exception as e:
-                    if verbose:
-                        logger.info(f"Standard format extraction failed: {e}, trying alternative formats...")
-                
-                # Method 2: Llama API format
-                if content is None:
-                    try:
-                        if hasattr(response, 'completion_message') and response.completion_message is not None:
-                            completion = response.completion_message
-                            # Handle dictionary case
-                            if isinstance(completion, dict) and 'content' in completion:
-                                content_obj = completion['content']
-                                # Different Llama API response formats
-                                if isinstance(content_obj, dict) and 'text' in content_obj:
-                                    content = content_obj['text']
-                                elif isinstance(content_obj, str):
-                                    content = content_obj
-                    except Exception as e:
-                        if verbose:
-                            logger.info(f"Llama API format extraction failed: {e}, trying dictionary access...")
-                
-                # Method 3: Try dictionary access for both formats
-                if content is None:
-                    try:
-                        # Convert to dictionary if possible
-                        response_dict = None
-                        if hasattr(response, 'model_dump'):
-                            response_dict = response.model_dump()
-                        elif hasattr(response, 'dict'):
-                            response_dict = response.dict()
-                        elif hasattr(response, '__dict__'):
-                            response_dict = response.__dict__
-                        elif isinstance(response, dict):
-                            response_dict = response
-                        
-                        if response_dict is not None:
-                            # Try Llama API format
-                            if 'completion_message' in response_dict and response_dict['completion_message'] is not None:
-                                comp = response_dict['completion_message']
-                                if isinstance(comp, dict) and 'content' in comp:
-                                    content_obj = comp['content']
-                                    if isinstance(content_obj, dict) and 'text' in content_obj:
-                                        content = content_obj['text']
-                                    elif isinstance(content_obj, str):
-                                        content = content_obj
-                            
-                            # Try OpenAI format
-                            if content is None and 'choices' in response_dict and response_dict['choices'] and len(response_dict['choices']) > 0:
-                                choice = response_dict['choices'][0]
-                                if isinstance(choice, dict) and 'message' in choice:
-                                    message = choice['message']
-                                    if isinstance(message, dict) and 'content' in message and message['content'] is not None:
-                                        content = message['content']
-                    except Exception as e:
-                        if verbose:
-                            logger.info(f"Dictionary access failed: {e}")
-                
-                # If content is still None, print detailed debug info
-                if content is None:
-                    if verbose or debug_mode:
-                        logger.error("Could not extract content from response using any known method")
-                        logger.error(f"Response: {response}")
-                        if isinstance(response, dict):
-                            for k, v in response.items():
-                                logger.error(f"Key: {k}, Value type: {type(v)}, Value: {v}")
-                        # Try to find any content-like fields
-                        all_attrs = dir(response)
-                        content_fields = [attr for attr in all_attrs if 'content' in attr.lower() or 'text' in attr.lower() or 'message' in attr.lower()]
-                        for field in content_fields:
-                            try:
-                                logger.error(f"Potential content field '{field}': {getattr(response, field, 'N/A')}")
-                            except:
-                                pass
-                    
-                    raise ValueError(f"Could not extract content from response using any known method")
-                
-                return content
-                
-            except Exception as e:
-                if verbose:
-                    logger.error(f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}")
-                
-                if attempt == self.max_retries - 1:
-                    return f"ERROR: {str(e)}"
-                
-                await asyncio.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def _openai_batch_completion(self,
-                                message_batches: List[List[Dict[str, str]]],
-                                temperature: float,
-                                max_tokens: int,
-                                top_p: float,
-                                batch_size: int,
-                                verbose: bool) -> List[str]:
-        """Process multiple message sets using the OpenAI API or compatible APIs asynchronously"""
-        debug_mode = os.environ.get('SDK_DEBUG', 'false').lower() == 'true'
-        results = []
-        
-        # Process message batches in chunks to avoid overloading the API
-        for i in range(0, len(message_batches), batch_size):
-            batch_chunk = message_batches[i:i+batch_size]
-            if verbose:
-                logger.info(f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests")
-            
-            # Define async batch processing function
-            async def process_batch():
-                tasks = []
-                for messages in batch_chunk:
-                    task = self._process_message_async(
-                        messages=messages,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
-                        top_p=top_p,
-                        verbose=verbose,
-                        debug_mode=debug_mode
-                    )
-                    tasks.append(task)
-                
-                # Process all messages in the batch concurrently
-                return await asyncio.gather(*tasks)
-            
-            # Run the async batch processing
-            batch_results = asyncio.run(process_batch())
-            results.extend(batch_results)
-            
-            # Small delay between batches to avoid rate limits
-            if i + batch_size < len(message_batches):
-                time.sleep(self.sleep_time)
-        
-        return results
-    
-    def _vllm_batch_completion(self,
-                         message_batches: List[List[Dict[str, str]]],
-                         temperature: float,
-                         max_tokens: int,
-                         top_p: float,
-                         batch_size: int,
-                         verbose: bool) -> List[str]:
-        """Process multiple message sets in true batches using vLLM's API with concurrent requests"""
-        results = []
-        
-        # Process message batches in chunks to avoid overloading the server
-        for i in range(0, len(message_batches), batch_size):
-            batch_chunk = message_batches[i:i+batch_size]
-            if verbose:
-                logger.info(f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests")
-            
-            # Run the async batch processing
-            batch_results = asyncio.run(self._process_vllm_batch_async(
-                batch_chunk, temperature, max_tokens, top_p, verbose, batch_size
-            ))
-            results.extend(batch_results)
-            
-            # Small delay between batches to avoid rate limits
-            if i + batch_size < len(message_batches):
-                time.sleep(self.sleep_time)
-        
-        return results
+    """High-level client that exposes a unified interface for chat and batch generation."""
 
-    async def _process_vllm_batch_async(self,
-                                  batch_chunk: List[List[Dict[str, str]]],
-                                  temperature: float,
-                                  max_tokens: int,
-                                  top_p: float,
-                                  verbose: bool,
-                                  batch_size: int) -> List[str]:
-        """Process a batch of requests asynchronously using aiohttp"""
-    
-        async def process_single_request(session: aiohttp.ClientSession, 
-                                       messages: List[Dict[str, str]],
-                                       semaphore: asyncio.Semaphore,
-                                       http_request_timeout: int,) -> str:
-            """Process a single request with retry logic"""
-            data = {
-                "model": self.model,
-                "messages": messages,
-                "temperature": temperature,
-                "max_tokens": max_tokens,
-                "top_p": top_p
-            }
-            
-            async with semaphore:  # Limit concurrent requests
-                for attempt in range(self.max_retries):
-                    try:
-                        if verbose and attempt == 0:  # Only log on first attempt
-                            logger.info(f"Sending async request to vLLM model {self.model}...")
-                        
-                        async with session.post(
-                            f"{self.api_base}/chat/completions",
-                            headers={"Content-Type": "application/json"},
-                            data=json.dumps(data),
-                            timeout=aiohttp.ClientTimeout(total=http_request_timeout)  # 300 minutes timeout
-                        ) as response:
-                            
-                            if verbose and attempt == 0:
-                                logger.info(f"Received response with status code: {response.status}")
-                            
-                            response.raise_for_status()
-                            response_json = await response.json()
-                            
-                            try:
-                                return response_json["choices"][0]["message"]["content"]
-                            except (KeyError, IndexError) as e:
-                                raise ValueError(f"Invalid response format: {e}")
-                    
-                    except asyncio.TimeoutError:
-                        error_msg = f"Request timeout on attempt {attempt + 1}/{self.max_retries}"
-                        if verbose:
-                            logger.warning(error_msg)
-                        if attempt == self.max_retries - 1:
-                            return f"ERROR: {error_msg}"
-                            
-                    except aiohttp.ClientError as e:
-                        error_msg = f"HTTP error on attempt {attempt + 1}/{self.max_retries}: {str(e)}"
-                        if verbose:
-                            logger.warning(error_msg)
-                        if attempt == self.max_retries - 1:
-                            return f"ERROR: {error_msg}"
-                            
-                    except Exception as e:
-                        error_msg = f"Unexpected error on attempt {attempt + 1}/{self.max_retries}: {str(e)}"
-                        if verbose:
-                            logger.warning(error_msg)
-                        if attempt == self.max_retries - 1:
-                            return f"ERROR: {error_msg}"
-                    
-                    # Exponential backoff between retries
-                    if attempt < self.max_retries - 1:
-                        await asyncio.sleep(self.retry_delay * (attempt + 1))
-        
-        # Create semaphore to limit concurrent connections (prevent overwhelming the server)
-        max_concurrent = min(batch_size, 1024)  # Cap at 1024 concurrent requests
-        semaphore = asyncio.Semaphore(max_concurrent)
-        
-        # Create aiohttp session with connection pooling
-        connector = aiohttp.TCPConnector(
-            limit=max_concurrent * 2,  # Total connection pool size
-            limit_per_host=max_concurrent,  # Connections per host
-            ttl_dns_cache=300,  # DNS cache TTL
-            use_dns_cache=True,
+    PROVIDER_REGISTRY = {
+        "openai-endpoint": OpenAIEndpointProvider,
+    }
+
+    def __init__(
+        self,
+        config_path: Optional[os.PathLike] = None,
+        provider: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model_name: Optional[str] = None,
+        max_retries: Optional[int] = None,
+        retry_delay: Optional[float] = None,
+        http_request_timeout: Optional[int] = None,
+    ):
+        self.config = load_config(config_path)
+
+        active_provider = provider or get_llm_provider(self.config)
+        self.provider = active_provider
+        self.provider_config = get_provider_config(self.config, active_provider)
+
+        overrides = {
+            "api_base": api_base,
+            "api_key": api_key,
+            "model_name": model_name,
+            "max_retries": max_retries,
+            "retry_delay": retry_delay,
+            "http_request_timeout": http_request_timeout,
+        }
+
+        self._provider_impl = self._initialize_provider(active_provider, self.provider_config, overrides)
+
+        self.model = self._provider_impl.model
+        self.max_retries = self._provider_impl.max_retries
+        self.retry_delay = self._provider_impl.retry_delay
+        self.sleep_time = getattr(self._provider_impl, "sleep_time", None)
+        self.api_base = getattr(self._provider_impl, "api_base", None)
+        self.http_request_timeout = getattr(self._provider_impl, "http_request_timeout", None)
+
+    def _initialize_provider(
+        self,
+        provider_name: str,
+        provider_config: Dict[str, Any],
+        overrides: Dict[str, Any],
+    ) -> BaseLLMProvider:
+        provider_class = self.PROVIDER_REGISTRY.get(provider_name)
+        if not provider_class:
+            raise ValueError(f"Unknown LLM provider '{provider_name}'")
+        return provider_class(provider_config, overrides)
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        top_p: Optional[float] = None,
+    ) -> str:
+        generation_config = self.config.get("generation", {})
+        temperature = temperature if temperature is not None else generation_config.get("temperature", 0.1)
+        max_tokens = max_tokens if max_tokens is not None else generation_config.get("max_tokens", 4096)
+        top_p = top_p if top_p is not None else generation_config.get("top_p", 0.95)
+
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
+        return self._provider_impl.chat_completion(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            verbose=verbose,
         )
-        
-        timeout = aiohttp.ClientTimeout(total=300)  # 5 minutes total timeout
-        
-        async with aiohttp.ClientSession(
-            connector=connector, 
-            timeout=timeout,
-            headers={"Content-Type": "application/json"}
-        ) as session:
-            # Create tasks for all requests in the batch
-            tasks = []
-            for messages in batch_chunk:
-                task = process_single_request(session, messages, semaphore, self.http_request_timeout)
-                tasks.append(task)
-            
-            if verbose:
-                logger.info(f"Starting {len(tasks)} concurrent requests...")
-            
-            # Execute all requests concurrently
-            results = await asyncio.gather(*tasks, return_exceptions=False)
-            
-            if verbose:
-                logger.info(f"Completed {len(results)} requests")
-            
-            return results
-    
+
+    def batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        top_p: Optional[float] = None,
+        batch_size: Optional[int] = None,
+    ) -> List[str]:
+        generation_config = self.config.get("generation", {})
+        temperature = temperature if temperature is not None else generation_config.get("temperature", 0.1)
+        max_tokens = max_tokens if max_tokens is not None else generation_config.get("max_tokens", 4096)
+        top_p = top_p if top_p is not None else generation_config.get("top_p", 0.95)
+        batch_size = batch_size if batch_size is not None else generation_config.get("batch_size", 32)
+
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
+        return self._provider_impl.batch_completion(
+            message_batches=message_batches,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            batch_size=batch_size,
+            verbose=verbose,
+        )
+
     @classmethod
-    def from_config(cls, config_path: Path) -> 'LLMClient':
-        """Create a client from configuration file"""
+    def from_config(cls, config_path: os.PathLike) -> "LLMClient":
+        """Create a client from configuration file."""
         return cls(config_path=config_path)

--- a/synthetic_data_kit/models/openai_provider.py
+++ b/synthetic_data_kit/models/openai_provider.py
@@ -33,13 +33,6 @@ class OpenAIEndpointProvider(BaseLLMProvider):
         env_api_key = next((os.environ.get(key) for key in env_keys if os.environ.get(key)), None)
 
         self.api_key = overrides.get("api_key") or env_api_key or config.get("api_key")
-        if not self.api_key and not self.require_api_key:
-            self.api_key = config.get("fallback_api_key", "EMPTY")
-        self.require_api_key = config.get("require_api_key", False)
-        if not self.api_key and self.require_api_key:
-            raise ValueError(
-                "API key is required for openai-endpoint provider. Set it in config or via environment variables."
-            )
 
         headers = config.get("headers", {})
         self.extra_headers = (

--- a/synthetic_data_kit/models/openai_provider.py
+++ b/synthetic_data_kit/models/openai_provider.py
@@ -1,0 +1,366 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+import asyncio
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List
+
+from openai import AsyncOpenAI, OpenAI, OpenAIError
+
+from synthetic_data_kit.models.base import BaseLLMProvider
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class OpenAIEndpointProvider(BaseLLMProvider):
+    """Provider that leverages the official OpenAI Python client library."""
+
+    def __init__(self, config: Dict[str, Any], overrides: Dict[str, Any]):
+        super().__init__("openai-endpoint", config, overrides)
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+        self.api_base = (
+            overrides.get("api_base")
+            or config.get("api_base")
+        )
+
+        env_keys = config.get("api_key_env_vars", ["OPENAI_API_KEY", "API_ENDPOINT_KEY"])
+        env_api_key = next((os.environ.get(key) for key in env_keys if os.environ.get(key)), None)
+
+        self.api_key = overrides.get("api_key") or env_api_key or config.get("api_key")
+        if not self.api_key and not self.require_api_key:
+            self.api_key = config.get("fallback_api_key", "EMPTY")
+        self.require_api_key = config.get("require_api_key", False)
+        if not self.api_key and self.require_api_key:
+            raise ValueError(
+                "API key is required for openai-endpoint provider. Set it in config or via environment variables."
+            )
+
+        headers = config.get("headers", {})
+        self.extra_headers = (
+            {str(k): str(v) for k, v in headers.items()} if isinstance(headers, dict) else {}
+        )
+
+        query_params = config.get("query_params", {})
+        self.extra_query = dict(query_params) if isinstance(query_params, dict) else {}
+
+        payload_overrides = config.get("payload_overrides", {})
+        self.payload_overrides = (
+            dict(payload_overrides) if isinstance(payload_overrides, dict) else {}
+        )
+
+        self.http_request_timeout = (
+            overrides.get("http_request_timeout")
+            or config.get("http_request_timeout", 300)
+        )
+
+        self.max_concurrent_requests = config.get("max_concurrent_requests", 32) or 32
+
+        client_kwargs: Dict[str, Any] = {
+        }
+        if self.api_base:
+            client_kwargs["base_url"] = self.api_base
+        if self.api_key:
+            client_kwargs["api_key"] = self.api_key
+        if self.extra_headers:
+            client_kwargs["default_headers"] = dict(self.extra_headers)
+
+        self._client_kwargs = client_kwargs
+        self._request_timeout = float(self.http_request_timeout) if self.http_request_timeout else None
+
+        self._client = OpenAI(**self._client_kwargs)
+        self._async_client = AsyncOpenAI(**self._client_kwargs)
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> str:
+        kwargs = self._build_request_kwargs(messages, temperature, max_tokens, top_p)
+        
+
+        for attempt in range(self.max_retries):
+            try:
+                if verbose and attempt == 0:
+                    self.logger.info("Sending request via OpenAI SDK to model %s...", self.model)
+
+                response = self._client.chat.completions.create(**kwargs)
+
+                if self.debug_mode:
+                    self.logger.debug("Raw SDK response: %s", response)
+
+                return self._extract_chat_content(response, verbose)
+
+            except (OpenAIError, ValueError, KeyError) as exc:
+                error_message = str(exc)
+                if verbose:
+                    self.logger.warning(
+                        "OpenAI SDK error (attempt %s/%s): %s",
+                        attempt + 1,
+                        self.max_retries,
+                        error_message,
+                    )
+
+                if attempt == self.max_retries - 1:
+                    raise Exception(
+                        f"Failed to get openai-endpoint completion after {self.max_retries} attempts: {error_message}"
+                    ) from exc
+
+                time.sleep(self.retry_delay * (attempt + 1)) # Exponential backoff
+
+        raise RuntimeError("Exceeded retry attempts without raising")
+
+    def batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        batch_size: int,
+        verbose: bool,
+    ) -> List[str]:
+        if not message_batches:
+            return []
+
+        batch_size = max(1, batch_size)
+        total_batches = (len(message_batches) + batch_size - 1) // batch_size
+        results: List[str] = []
+
+        for index in range(0, len(message_batches), batch_size):
+            batch_chunk = message_batches[index:index + batch_size]
+            batch_number = index // batch_size + 1
+
+            if verbose:
+                self.logger.info(
+                    "Processing batch %s/%s with %s requests via OpenAI SDK",
+                    batch_number,
+                    total_batches,
+                    len(batch_chunk),
+                )
+
+            chunk_results = self._run_coroutine(
+                self._process_batch_async(batch_chunk, temperature, max_tokens, top_p, verbose)
+            )
+            results.extend(chunk_results)
+
+            if index + batch_size < len(message_batches):
+                time.sleep(self.sleep_time)
+
+        return results
+
+    def _build_request_kwargs(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+    ) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "top_p": top_p,
+        }
+        if self.payload_overrides:
+            kwargs.update(self.payload_overrides)
+        if self.extra_headers:
+            kwargs["extra_headers"] = self.extra_headers
+        if self.extra_query:
+            kwargs["extra_query"] = self.extra_query
+        if self._request_timeout is not None:
+            kwargs["timeout"] = self._request_timeout
+        return kwargs
+
+    async def _process_batch_async(
+        self,
+        batch_chunk: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> List[str]:
+        if not batch_chunk:
+            return []
+
+        max_concurrent = self.max_concurrent_requests or len(batch_chunk)
+        max_concurrent = max(1, min(max_concurrent, len(batch_chunk)))
+
+        # Create semaphore to limit concurrent connections (prevent overwhelming the server)
+        semaphore = asyncio.Semaphore(max_concurrent)
+        tasks = [
+            self._process_single_request(messages, semaphore, temperature, max_tokens, top_p, verbose)
+            for messages in batch_chunk
+        ]
+        return await asyncio.gather(*tasks, return_exceptions=False)
+
+    async def _process_single_request(
+        self,
+        messages: List[Dict[str, str]],
+        semaphore: asyncio.Semaphore,
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+    ) -> str:
+        kwargs = self._build_request_kwargs(messages, temperature, max_tokens, top_p)
+        debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
+
+        for attempt in range(self.max_retries):
+            try:
+                async with semaphore:
+                    if verbose and attempt == 0:
+                        self.logger.info(
+                            "Sending async request via OpenAI SDK to model %s...",
+                            self.model,
+                        )
+
+                    response = await self._async_client.chat.completions.create(**kwargs)
+
+                    if debug_mode:
+                        self.logger.debug("Raw async SDK response: %s", response)
+
+                    return self._extract_chat_content(response, verbose)
+
+            except (OpenAIError, asyncio.TimeoutError, ValueError, KeyError) as exc:
+                error_message = f"{type(exc).__name__}: {exc}"
+                if attempt == self.max_retries - 1:
+                    if verbose:
+                        self.logger.warning(
+                            "OpenAI async request failed after %s attempts: %s",
+                            self.max_retries,
+                            error_message,
+                        )
+                    return f"ERROR: {error_message}"
+
+                await asyncio.sleep(self.retry_delay * (attempt + 1)) # Exponential backoff
+
+        return "ERROR: exceeded retry attempts"
+
+    def _run_coroutine(self, coroutine: asyncio.Future) -> Any:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            return self._run_coroutine_in_thread(coroutine)
+
+        return asyncio.run(coroutine)
+
+    def _run_coroutine_in_thread(self, coroutine: asyncio.Future) -> Any:
+        result_container: Dict[str, Any] = {}
+
+        def runner() -> None:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                result_container["result"] = new_loop.run_until_complete(coroutine)
+            except Exception as exc:
+                result_container["error"] = exc
+            finally:
+                new_loop.run_until_complete(new_loop.shutdown_asyncgens())
+                new_loop.close()
+                asyncio.set_event_loop(None)
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        thread.join()
+    
+        if "error" in result_container:
+            raise result_container["error"]
+
+        return result_container.get("result", [])
+    
+    def _extract_chat_content(self, response: Any, verbose: bool) -> str:
+        """Extract primary message content from an OpenAI-style chat response."""
+        if response is None:
+            raise ValueError("Empty response from provider")
+
+        # Method 1: Try standard OpenAI API response format
+        try:
+            if hasattr(response, 'choices') and response.choices is not None and len(response.choices) > 0:
+                choice = response.choices[0]
+                if hasattr(choice, 'message') and choice.message is not None:
+                    if hasattr(choice.message, 'content') and choice.message.content is not None:
+                        return choice.message.content
+        except Exception as e:
+            if verbose:
+                self.logger.info(f"Standard format extraction failed: {e}, trying alternative formats...")
+        
+        # Method 2: Llama API format
+        try:
+            if hasattr(response, 'completion_message') and response.completion_message is not None:
+                completion = response.completion_message
+                # Handle dictionary case
+                if isinstance(completion, dict) and 'content' in completion:
+                    content = completion['content']
+                    # Different Llama API response formats
+                    if isinstance(content, dict) and 'text' in content:
+                        return content['text']
+                    elif isinstance(content, str):
+                        return content
+        except Exception as e:
+            if verbose:
+                self.logger.info(f"Llama API format extraction failed: {e}, trying dictionary access...")
+        
+        # Method 3: Try dictionary access for both formats
+        try:
+            # Convert to dictionary if possible
+            response_dict = None
+            if hasattr(response, 'model_dump'):
+                response_dict = response.model_dump()
+            elif hasattr(response, 'dict'):
+                response_dict = response.dict()
+            elif hasattr(response, '__dict__'):
+                response_dict = response.__dict__
+            elif isinstance(response, dict):
+                response_dict = response
+            
+            if response_dict is not None:
+                # Try Llama API format
+                if 'completion_message' in response_dict and response_dict['completion_message'] is not None:
+                    comp = response_dict['completion_message']
+                    if isinstance(comp, dict) and 'content' in comp:
+                        content = comp['content']
+                        if isinstance(content, dict) and 'text' in content:
+                            return content['text']
+                        elif isinstance(content, str):
+                            return content
+                
+                # Try OpenAI format
+                if 'choices' in response_dict and response_dict['choices'] is not None and len(response_dict['choices']) > 0:
+                    choice = response_dict['choices'][0]
+                    if isinstance(choice, dict) and 'message' in choice:
+                        message = choice['message']
+                        if isinstance(message, dict) and 'content' in message and message['content'] is not None:
+                            return message['content']
+        except Exception as e:
+            if verbose:
+                self.logger.info(f"Dictionary access failed: {e}")
+        
+        # Last resort: Try to print the full response for debugging
+        if verbose or self.debug_mode:
+            self.logger.error("Could not extract content from response using any known method")
+            self.logger.error(f"Response: {response}")
+            if isinstance(response, dict):
+                for k, v in response.items():
+                    self.logger.error(f"Key: {k}, Value type: {type(v)}, Value: {v}")
+            # Try to find any content-like fields
+            all_attrs = dir(response)
+            content_fields = [attr for attr in all_attrs if 'content' in attr.lower() or 'text' in attr.lower() or 'message' in attr.lower()]
+            for field in content_fields:
+                try:
+                    self.logger.error(f"Potential content field '{field}': {getattr(response, field, 'N/A')}")
+                except:
+                    pass
+        
+        raise ValueError(f"Could not extract content from response using any known method")

--- a/synthetic_data_kit/utils/__init__.py
+++ b/synthetic_data_kit/utils/__init__.py
@@ -5,14 +5,18 @@
 # the root directory of this source tree.
 # Utility files for all classes
 from synthetic_data_kit.utils.config import (
-    load_config, 
-    get_path_config, 
-    get_vllm_config, 
+    load_config,
+    get_path_config,
+    get_provider_config,
+    get_openai_endpoint_config,
     get_generation_config,
     get_curate_config,
     get_format_config,
     get_prompt,
     merge_configs,
+    get_llm_provider,
+    get_vllm_config,
+    get_openai_config,
 )
 from synthetic_data_kit.utils.text import split_into_chunks, extract_json_from_text
 from synthetic_data_kit.utils.llm_processing import (

--- a/synthetic_data_kit/utils/config.py
+++ b/synthetic_data_kit/utils/config.py
@@ -6,8 +6,12 @@
 # Config Utilities
 import yaml
 import os
+import warnings
+import logging
 from pathlib import Path
 from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
 
 # Default config location relative to the package (original)
 ORIGINAL_CONFIG_PATH = os.path.abspath(
@@ -22,6 +26,28 @@ PACKAGE_CONFIG_PATH = os.path.abspath(
 
 # Use internal package path as default
 DEFAULT_CONFIG_PATH = PACKAGE_CONFIG_PATH
+
+LEGACY_PROVIDER_ALIASES = {
+    "vllm": "openai-endpoint",
+    "api-endpoint": "openai-endpoint",
+}
+
+LEGACY_CONFIG_SECTION_ALIASES = {
+    "openai-endpoint": ("api-endpoint", "vllm"),
+}
+
+DEFAULT_PROVIDER_CONFIGS = {
+    "openai-endpoint": {
+        "api_base": "https://api.openai.com/v1",
+        "model": "gpt-4o",
+        "max_retries": 3,
+        "retry_delay": 1.0,
+        "sleep_time": 0.5,
+        "http_request_timeout": 300,
+        "max_concurrent_requests": 32,
+        "api_key": None,
+    },
+}
 
 def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
     """Load YAML configuration file"""
@@ -76,37 +102,86 @@ def get_path_config(config: Dict[str, Any], path_type: str, file_type: Optional[
         raise ValueError(f"Unknown path type: {path_type}")
 
 def get_llm_provider(config: Dict[str, Any]) -> str:
-    """Get the selected LLM provider
-    
-    Returns:
-        String with provider name: 'vllm' or 'api-endpoint'
-    """
+    """Get the selected LLM provider."""
     llm_config = config.get('llm', {})
-    provider = llm_config.get('provider', 'vllm')
+    provider = llm_config.get('provider', 'openai-endpoint')
     print(f"get_llm_provider returning: {provider}")
-    if provider != 'api-endpoint' and 'llm' in config and 'provider' in config['llm'] and config['llm']['provider'] == 'api-endpoint':
-        print(f"WARNING: Config has 'api-endpoint' but returning '{provider}'")
     return provider
 
+
+def get_provider_config(config: Dict[str, Any], provider: str) -> Dict[str, Any]:
+    """Return provider configuration merged with defaults and legacy aliases."""
+    base_config: Dict[str, Any] = DEFAULT_PROVIDER_CONFIGS.get(provider, {}).copy()
+
+    explicit_config = config.get(provider, {})
+    if isinstance(explicit_config, dict):
+        base_config = merge_configs(base_config, explicit_config)
+
+    providers_section = config.get('providers', {})
+    if isinstance(providers_section, dict):
+        nested_config = providers_section.get(provider, {})
+        if isinstance(nested_config, dict):
+            base_config = merge_configs(base_config, nested_config)
+
+    for legacy_key in LEGACY_CONFIG_SECTION_ALIASES.get(provider, ()):
+        legacy_config = config.get(legacy_key)
+        if isinstance(legacy_config, dict):
+            warnings.warn(
+                f"Config section '{legacy_key}' is deprecated. Rename it to '{provider}'.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            logger.warning(
+                "Config section '%s' is deprecated. Treating it as '%s'.",
+                legacy_key,
+                provider,
+            )
+            base_config = merge_configs(base_config, legacy_config)
+
+    return base_config
+
 def get_vllm_config(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Get VLLM configuration"""
-    return config.get('vllm', {
+    """Get VLLM configuration (legacy helper)."""
+    warnings.warn(
+        "get_vllm_config is deprecated. Use get_provider_config(..., 'openai-endpoint') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    provider_config = get_provider_config(config, 'openai-endpoint')
+    defaults = {
         'api_base': 'http://localhost:8000/v1',
         'port': 8000,
-        'model': 'meta-llama/Llama-3.3-70B-Instruct',
-        'max_retries': 3,
-        'retry_delay': 1.0
-    })
+        'model': provider_config.get('model', 'meta-llama/Llama-3.3-70B-Instruct'),
+        'max_retries': provider_config.get('max_retries', 3),
+        'retry_delay': provider_config.get('retry_delay', 1.0),
+        'sleep_time': provider_config.get('sleep_time', 0.1),
+        'http_request_timeout': provider_config.get('http_request_timeout', 180),
+    }
+    return merge_configs(defaults, provider_config)
 
 def get_openai_config(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Get API endpoint configuration"""
-    return config.get('api-endpoint', {
-        'api_base': None,  # None means use default API base URL
-        'api_key': None,  # None means use environment variables
-        'model': 'gpt-4o',
-        'max_retries': 3,
-        'retry_delay': 1.0
-    })
+    """Get OpenAI endpoint configuration (legacy helper)."""
+    warnings.warn(
+        "get_openai_config is deprecated. Use get_provider_config(..., 'openai-endpoint') instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    provider_config = get_provider_config(config, 'openai-endpoint')
+    defaults = {
+        'api_base': provider_config.get('api_base', 'https://api.openai.com/v1'),
+        'api_key': provider_config.get('api_key'),
+        'model': provider_config.get('model', 'gpt-4o'),
+        'max_retries': provider_config.get('max_retries', 3),
+        'retry_delay': provider_config.get('retry_delay', 1.0),
+        'sleep_time': provider_config.get('sleep_time', 0.5),
+        'http_request_timeout': provider_config.get('http_request_timeout', 300),
+    }
+    return merge_configs(defaults, provider_config)
+
+
+def get_openai_endpoint_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Preferred helper for OpenAI-compatible endpoints."""
+    return get_provider_config(config, 'openai-endpoint')
 
 def get_generation_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Get generation configuration"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 
 import pytest
 
+from synthetic_data_kit.cli import ctx
+
 # Import our test utilities
 from tests.utils import TempDirectoryManager
 
@@ -153,17 +155,22 @@ class MockConfigFactory:
     """Factory for creating various mock configurations."""
 
     @staticmethod
-    def create_api_config(provider="api-endpoint", api_key="mock-key", model="mock-model"):
-        """Create a mock API endpoint configuration."""
-        return {
+    def create_api_config(provider="openai-endpoint", api_key="mock-key", model="mock-model"):
+        """Create a mock OpenAI-compatible endpoint configuration."""
+        endpoint_config = {
+            "api_base": "https://api.together.xyz/v1",
+            "api_key": api_key,
+            "model": model,
+            "max_retries": 3,
+            "retry_delay": 1,
+            "sleep_time": 0.5,
+            "http_request_timeout": 300,
+            "max_concurrent_requests": 32,
+        }
+
+        config_dict = {
             "llm": {"provider": provider},
-            "api-endpoint": {
-                "api_base": "https://api.together.xyz/v1",
-                "api_key": api_key,
-                "model": model,
-                "max_retries": 3,
-                "retry_delay": 1,
-            },
+            "openai-endpoint": endpoint_config,
             "generation": {
                 "temperature": 0.7,
                 "max_tokens": 4096,
@@ -176,6 +183,12 @@ class MockConfigFactory:
             },
         }
 
+        if provider in {"api-endpoint", "vllm"}:
+            # Include legacy keys to exercise backward compatibility paths
+            config_dict[provider] = endpoint_config
+
+        return config_dict
+
     @staticmethod
     def create_vllm_config(model="mock-vllm-model"):
         """Create a mock vLLM configuration."""
@@ -186,6 +199,18 @@ class MockConfigFactory:
                 "model": model,
                 "max_retries": 3,
                 "retry_delay": 1,
+                "sleep_time": 0.1,
+                "http_request_timeout": 180,
+            },
+            "openai-endpoint": {
+                "api_base": "http://localhost:8000",
+                "model": model,
+                "max_retries": 3,
+                "retry_delay": 1,
+                "sleep_time": 0.1,
+                "http_request_timeout": 180,
+                "require_api_key": False,
+                "server_start_hint": f"Start vLLM with: vllm serve {model}",
             },
             "generation": {
                 "temperature": 0.1,
@@ -231,17 +256,29 @@ def test_env():
 @pytest.fixture
 def patch_config(config_factory):
     """Patch the config loader to return a mock configuration."""
+    config = config_factory.create_api_config()
     with patch("synthetic_data_kit.utils.config.load_config") as mock_load_config:
-        mock_load_config.return_value = config_factory.create_api_config()
-        yield mock_load_config
+        mock_load_config.return_value = config
+        original_config = ctx.config
+        ctx.update_config(config)
+        try:
+            yield mock_load_config
+        finally:
+            ctx.update_config(original_config)
 
 
 @pytest.fixture
 def patch_vllm_config(config_factory):
     """Patch the config loader to return a vLLM configuration."""
+    config = config_factory.create_vllm_config()
     with patch("synthetic_data_kit.utils.config.load_config") as mock_load_config:
-        mock_load_config.return_value = config_factory.create_vllm_config()
-        yield mock_load_config
+        mock_load_config.return_value = config
+        original_config = ctx.config
+        ctx.update_config(config)
+        try:
+            yield mock_load_config
+        finally:
+            ctx.update_config(original_config)
 
 
 # Additional utility fixtures for common test patterns
@@ -300,15 +337,6 @@ def sample_conversations():
             ]
         },
     ]
-#New fixtures
-@pytest.fixture
-def cli_helper():
-    """Fixture providing CLI test helper with common utilities.
-    
-    This replaces manual CLI testing setup in functional tests.
-    """
-    from synthetic_data_kit.cli import app
-    return CLITestHelper(app)
 
 
 @pytest.fixture

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -12,41 +12,38 @@ from synthetic_data_kit.cli import app
 
 
 @pytest.mark.functional
-def test_system_check_command_vllm(patch_config):
-    """Test the system-check command with vLLM provider."""
+@pytest.mark.parametrize("provider", ["vllm", "api-endpoint"])
+def test_system_check_command_unsupported_provider(provider, patch_config, test_env):
+    """Unsupported providers should exit with a warning message."""
     runner = CliRunner()
 
-    # Mock the requests.get to simulate a vLLM server response
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = ["Llama-3-70B-Instruct"]
-        mock_get.return_value = mock_response
+    result = runner.invoke(app, ["system-check", "--provider", provider])
 
-        result = runner.invoke(app, ["system-check", "--provider", "vllm"])
-
-        assert result.exit_code == 0
-        # Check for general success rather than specific message
-        assert "vLLM server is running" in result.stdout
-        mock_get.assert_called_once()
+    assert f"System check for provider '{provider}' is not implemented yet." in result.stdout
 
 
 @pytest.mark.functional
-def test_system_check_command_api_endpoint(patch_config, test_env):
-    """Test the system-check command with API endpoint provider."""
+def test_system_check_command_openai_endpoint(patch_config, test_env):
+    """System check should call the OpenAI SDK when using the default provider."""
     runner = CliRunner()
 
-    # Mock OpenAI API client
     with patch("openai.OpenAI") as mock_openai:
         mock_client = MagicMock()
-        mock_client.models.list.return_value = ["mock-model"]
         mock_openai.return_value = mock_client
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock(content="hello world")
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_client.chat.completions.create.return_value = mock_response
 
-        result = runner.invoke(app, ["system-check", "--provider", "api-endpoint"])
+        result = runner.invoke(app, ["system-check"])
 
-        # Just check exit code, not specific message since it varies
-        assert result.exit_code == 0
-        mock_openai.assert_called_once()
+    assert result.exit_code == 0
+    assert "API key source" in result.stdout
+    assert "API endpoint access confirmed" in result.stdout
+    assert "hello world" in result.stdout
+    mock_client.chat.completions.create.assert_called_once()
 
 
 @pytest.mark.functional

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -41,13 +41,13 @@ def test_parse_qa_pairs_invalid_json():
 @pytest.mark.unit
 def test_llm_client_error_handling(patch_config, test_env):
     """Test error handling in LLM client."""
-    with patch("synthetic_data_kit.models.llm_client.OpenAI") as mock_openai:
+    with patch("synthetic_data_kit.models.openai_provider.OpenAI") as mock_openai:
         # Setup mock to raise an exception
         mock_openai.side_effect = Exception("API Error")
 
         # Should handle the exception gracefully
         with pytest.raises(Exception) as excinfo:
-            LLMClient(provider="api-endpoint")
+            LLMClient(provider="openai-endpoint")
 
         # Check that the error message is helpful
         assert "API Error" in str(excinfo.value)

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -1,6 +1,6 @@
 """Unit tests for LLM client."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -9,74 +9,41 @@ from synthetic_data_kit.models.llm_client import LLMClient
 
 @pytest.mark.unit
 def test_llm_client_initialization(patch_config, test_env):
-    """Test LLM client initialization with API endpoint provider."""
-    with patch("synthetic_data_kit.models.llm_client.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_openai.return_value = mock_client
+    """LLM client should initialize the OpenAI provider using SDK clients."""
+    with patch("synthetic_data_kit.models.openai_provider.OpenAI") as mock_openai, patch(
+        "synthetic_data_kit.models.openai_provider.AsyncOpenAI"
+    ) as mock_async_openai:
+        mock_openai.return_value = MagicMock()
+        mock_async_openai.return_value = MagicMock()
 
-        # Initialize client
-        client = LLMClient(provider="api-endpoint")
+        client = LLMClient()
 
-        # Check that the client was initialized correctly
-        assert client.provider == "api-endpoint"
-        assert client.api_base is not None
+        assert client.provider == "openai-endpoint"
         assert client.model is not None
-        # Check that OpenAI client was initialized
-        assert mock_openai.called
-
-
-@pytest.mark.unit
-def test_llm_client_vllm_initialization(patch_config, test_env):
-    """Test LLM client initialization with vLLM provider."""
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = ["mock-model"]
-        mock_get.return_value = mock_response
-
-        # Initialize client
-        client = LLMClient(provider="vllm")
-
-        # Check that the client was initialized correctly
-        assert client.provider == "vllm"
         assert client.api_base is not None
-        assert client.model is not None
-        # Check that vLLM server was checked
-        assert mock_get.called
+        mock_openai.assert_called_once()
+        mock_async_openai.assert_called_once()
 
 
 @pytest.mark.unit
 def test_llm_client_chat_completion(patch_config, test_env):
-    """Test LLM client chat completion with API endpoint provider."""
-    with patch("synthetic_data_kit.models.llm_client.OpenAI") as mock_openai:
-        # Create a proper mock chain for OpenAI client
+    """chat_completion should delegate to the OpenAI SDK and return extracted text."""
+    with patch("synthetic_data_kit.models.openai_provider.OpenAI") as mock_openai, patch(
+        "synthetic_data_kit.models.openai_provider.AsyncOpenAI"
+    ) as mock_async_openai:
+        mock_async_openai.return_value = MagicMock()
+
         mock_client = MagicMock()
-        mock_chat = MagicMock()
-        mock_completions = MagicMock()
-        mock_create = MagicMock()
-
-        # Setup the nested mock structure
         mock_openai.return_value = mock_client
-        mock_client.chat = mock_chat
-        mock_chat.completions = mock_completions
-        mock_completions.create = mock_create
-
-        # Setup mock response
-        mock_response = MagicMock()
+        mock_completion = MagicMock()
         mock_choice = MagicMock()
-        mock_message = MagicMock()
-
-        mock_message.content = "This is a test response"
+        mock_message = MagicMock(content="This is a test response")
         mock_choice.message = mock_message
-        mock_response.choices = [mock_choice]
+        mock_completion.choices = [mock_choice]
+        mock_client.chat.completions.create.return_value = mock_completion
 
-        # Connect the create function to return our mock response
-        mock_create.return_value = mock_response
+        client = LLMClient()
 
-        # Initialize client
-        client = LLMClient(provider="api-endpoint")
-
-        # Test chat completion
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What is synthetic data?"},
@@ -84,42 +51,48 @@ def test_llm_client_chat_completion(patch_config, test_env):
 
         response = client.chat_completion(messages, temperature=0.7)
 
-        # Check that the response is correct
         assert response == "This is a test response"
-        # Check that OpenAI client was called
-        assert mock_create.called
+        mock_client.chat.completions.create.assert_called_once()
 
 
 @pytest.mark.unit
-def test_llm_client_vllm_chat_completion(patch_config, test_env):
-    """Test LLM client chat completion with vLLM provider."""
-    with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
-        # Mock vLLM server check
-        mock_check_response = MagicMock()
-        mock_check_response.status_code = 200
-        mock_check_response.json.return_value = ["mock-model"]
-        mock_get.return_value = mock_check_response
+def test_llm_client_batch_completion(patch_config, test_env):
+    """batch_completion should dispatch multiple async SDK calls."""
+    with patch("synthetic_data_kit.models.openai_provider.OpenAI") as mock_openai, patch(
+        "synthetic_data_kit.models.openai_provider.AsyncOpenAI"
+    ) as mock_async_openai, patch(
+        "synthetic_data_kit.models.openai_provider.time.sleep"
+    ) as mock_sleep:
+        mock_sleep.return_value = None
 
-        # Mock vLLM API response
+        mock_sync_client = MagicMock()
+        mock_async_client = MagicMock()
+        mock_openai.return_value = mock_sync_client
+        mock_async_openai.return_value = mock_async_client
+
         mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "This is a test response"}}]
-        }
-        mock_post.return_value = mock_response
+        mock_choice = MagicMock()
+        mock_choice.message = MagicMock(content="batch result")
+        mock_response.choices = [mock_choice]
 
-        # Initialize client
-        client = LLMClient(provider="vllm")
+        async_create = AsyncMock(return_value=mock_response)
+        mock_async_client.chat.completions.create = async_create
 
-        # Test chat completion
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "What is synthetic data?"},
+        client = LLMClient()
+
+        batches = [
+            [{"role": "user", "content": "Hello"}],
+            [{"role": "user", "content": "World"}],
         ]
 
-        response = client.chat_completion(messages, temperature=0.7)
+        results = client.batch_completion(batches, temperature=0.1, max_tokens=16, top_p=0.9, batch_size=1)
 
-        # Check that the response is correct
-        assert response == "This is a test response"
-        # Check that vLLM API was called
-        assert mock_post.called
+        assert results == ["batch result", "batch result"]
+        assert async_create.await_count == len(batches)
+
+
+@pytest.mark.unit
+def test_llm_client_unknown_provider_raises(patch_config):
+    """Requesting an unsupported provider should fail fast."""
+    with pytest.raises(ValueError):
+        LLMClient(provider="unknown-provider")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -118,12 +118,16 @@ def test_load_config(tmpdir):
 def test_get_llm_provider(mock_config):
     """Test getting the LLM provider from config."""
     provider = config.get_llm_provider(mock_config)
-    assert provider == "api-endpoint"
+    assert provider == "openai-endpoint"
 
     # Test with empty config
     empty_config = {}
     default_provider = config.get_llm_provider(empty_config)
-    assert default_provider == "vllm"  # Should return the default provider
+    assert default_provider == "openai-endpoint"
+
+    legacy_config = {"llm": {"provider": "api-endpoint"}}
+    normalized = config.get_llm_provider(legacy_config)
+    assert normalized == "api-endpoint"
 
 
 @pytest.mark.unit

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -121,7 +121,15 @@ class MockConfigHelper:
                 }
             },
             'llm': {
-                'provider': 'vllm'
+                'provider': 'openai-endpoint'
+            },
+            'openai-endpoint': {
+                'api_base': 'http://localhost:8000/v1',
+                'model': 'test-model',
+                'max_retries': 3,
+                'retry_delay': 1,
+                'sleep_time': 0.1,
+                'http_request_timeout': 180,
             },
             'vllm': {
                 'api_base': 'http://localhost:8000/v1',
@@ -133,12 +141,14 @@ class MockConfigHelper:
     def create_api_endpoint_config() -> Dict[str, Any]:
         """Create a mock configuration for API endpoint provider."""
         config = MockConfigHelper.create_default_config()
-        config['llm']['provider'] = 'api-endpoint'
-        config['api-endpoint'] = {
+        config['llm']['provider'] = 'openai-endpoint'
+        config['openai-endpoint'] = {
             'api_base': 'https://api.example.com/v1',
             'model': 'gpt-4',
-            'api_key': 'test-key'
+            'api_key': 'test-key',
         }
+        # Provide legacy alias for compatibility checks
+        config['api-endpoint'] = config['openai-endpoint']
         return config
 
 


### PR DESCRIPTION
# Pull Request

## Description

Currently http requests to the vllm server are sent out sequentially instead of in batches.
See #67 and #68 for reference.

I initially encountered this during the synthetic data & agents hackathon and solved this with a threadpool via `concurrent.futures`.
But since we are not actually doing any work (on the synthetic-data-kit side) in these threads, the solution from @HarshVaragiya  using a more lightweight `asyncio` approach is much better - since we are essentially just spawning http requests and are "waiting in parallel".

<details>
  <summary>Benchmarks</summary>
  
OpenAI Batching (Provider=api-endpoint) OLD:
Single request latency (overall): count=10 min=18.235s median=35.391s mean=35.944s max=55.202s
Single request latency (short prompt): count=5 min=18.235s median=25.101s mean=24.447s max=29.872s
Single request latency (long prompt): count=5 min=40.909s median=47.113s mean=47.440s max=55.202s
Batch latency (overall, batch_size=8): count=10 min=3.706s median=5.348s mean=5.503s max=7.385s
Batch latency (short-only, batch_size=8): count=5 min=3.706s median=4.149s mean=4.667s max=6.908s
Batch latency (1 long prompt(s), batch_size=8): count=5 min=4.671s median=6.634s mean=6.339s max=7.385s
-> 13m 40s

VLLM "Batching" (Provider=vllm) OLD:
Single request latency (overall): count=10 min=15.975s median=30.439s mean=31.472s max=50.811s
Single request latency (short prompt): count=5 min=15.975s median=18.694s mean=20.331s max=31.216s
Single request latency (long prompt): count=5 min=29.662s median=49.092s mean=42.613s max=50.811s
Batch latency (overall, batch_size=8): count=10 min=18.593s median=22.035s mean=21.966s max=25.405s
Batch latency (short-only, batch_size=8): count=5 min=18.593s median=21.603s mean=20.949s max=23.406s
Batch latency (1 long prompt(s), batch_size=8): count=5 min=21.281s median=22.955s mean=22.984s max=25.405s
-> 34 min 50s
-> essentially as slow as processing sequentially (because it is)


VLLM Batching (Provider=vllm) NEW (HarshVaragiya) https://github.com/meta-llama/synthetic-data-kit/pull/68:
Single request latency (overall): count=10 min=13.990s median=31.602s mean=29.933s max=47.919s
Single request latency (short prompt): count=5 min=13.990s median=19.956s mean=21.075s max=31.802s
Single request latency (long prompt): count=5 min=31.403s median=38.369s mean=38.791s max=47.919s
Batch latency (overall, batch_size=8): count=10 min=3.025s median=4.228s mean=4.842s max=6.649s
Batch latency (short-only, batch_size=8): count=5 min=3.025s median=3.740s mean=3.635s max=4.367s
Batch latency (1 long prompt(s), batch_size=8): count=5 min=4.090s median=6.498s mean=6.050s max=6.649s
-> 11 min 56s

</details>


However since `vllm serve` essentially exposes an openai-compatible API it makes sense to actually merge the `vllm`
and `api-endpoint` provider into a single one. So logic for this can be centralized and the synthetic-data-kit can be easily extended with new providers.


Fixes # (issue)

#67 

## Type of change

Please non-releavant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (kinda breaking since the config is updated, but it is made backwards compatible with api-endpoint and vllm providers for now)
- [ ] Documentation update