### PR TITLE
feat added: QA pairs to generate by chunk size

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -48,6 +48,7 @@ generation:
   overlap: 200       # Overlap between chunks to maintain context
   max_tokens: 4096   # Maximum tokens in LLM responses
   num_pairs: 25      # Default number of QA pairs to generate
+  num_pairs_per_chunk: null  # Alternative: number of QA pairs per chunk (null = use num_pairs instead)
   num_cot_examples: 5  # Default number of Chain of Thought examples to generate
   num_cot_enhance_examples: null  # Maximum number of conversations to enhance (null = enhance all)
   batch_size: 32     # Number of requests to batch together (for create)

--- a/synthetic_data_kit/cli.py
+++ b/synthetic_data_kit/cli.py
@@ -290,7 +290,10 @@ def create(
         None, "--model", "-m", help="Model to use"
     ),
     num_pairs: Optional[int] = typer.Option(
-        None, "--num-pairs", "-n", help="Target number of QA pairs or CoT examples to generate"
+        None, "--num-pairs", "-n", help="Target number of QA pairs or CoT examples to generate (total per document)"
+    ),
+    num_pairs_per_chunk: Optional[int] = typer.Option(
+        None, "--num-pairs-per-chunk", help="Number of QA pairs to generate per chunk (scales with document size, takes precedence over --num-pairs)"
     ),
     chunk_size: Optional[int] = typer.Option(
         None, "--chunk-size", help="Size of text chunks for processing large documents (default: 4000)"
@@ -313,9 +316,11 @@ def create(
     - Directory: synthetic-data-kit create ./processed-text/ --type qa
     
     Content types:
-    - qa: Generate question-answer pairs from .txt files (use --num-pairs to specify how many)
+    - qa: Generate question-answer pairs from .txt files
+      Use --num-pairs for total pairs per document OR --num-pairs-per-chunk to scale with document size
     - summary: Generate summaries from .txt files
-    - cot: Generate Chain of Thought reasoning examples from .txt files (use --num-pairs to specify how many)
+    - cot: Generate Chain of Thought reasoning examples from .txt files
+      Use --num-pairs for total examples OR --num-pairs-per-chunk to scale with document size
     - multimodal-qa: Generate question-answer pairs from .lance files (use --num-pairs to specify how many)
     - cot-enhance: Enhance existing conversations with Chain of Thought reasoning from .json files
       (use --num-pairs to limit the number of conversations to enhance, default is to enhance all)
@@ -411,6 +416,7 @@ def create(
                 model=model,
                 content_type=content_type,
                 num_pairs=num_pairs,
+                num_pairs_per_chunk=num_pairs_per_chunk,
                 verbose=verbose,
                 provider=provider,
                 chunk_size=chunk_size,
@@ -441,7 +447,8 @@ def create(
                     verbose,
                     provider=provider,
                     chunk_size=chunk_size,
-                    chunk_overlap=chunk_overlap
+                    chunk_overlap=chunk_overlap,
+                    num_pairs_per_chunk=num_pairs_per_chunk
                 )
             if output_path:
                 console.print(f"✅ Content saved to [bold]{output_path}[/bold]", style="green")

--- a/synthetic_data_kit/config.yaml
+++ b/synthetic_data_kit/config.yaml
@@ -56,7 +56,8 @@ generation:
   max_tokens: 4096   # Maximum tokens in LLM responses
   
   # Content generation targets
-  num_pairs: 25      # Default number of QA pairs to generate
+  num_pairs: 25      # Default number of QA pairs to generate (per document)
+  num_pairs_per_chunk: null  # Alternative: number of QA pairs per chunk (null = use num_pairs instead)
   num_cot_examples: 5  # Default number of Chain of Thought examples to generate
   num_cot_enhance_examples: null  # Maximum number of conversations to enhance (null = enhance all)
   

--- a/synthetic_data_kit/utils/directory_processor.py
+++ b/synthetic_data_kit/utils/directory_processor.py
@@ -219,6 +219,7 @@ def process_directory_create(
     model: Optional[str] = None,
     content_type: str = "qa",
     num_pairs: Optional[int] = None,
+    num_pairs_per_chunk: Optional[int] = None,
     verbose: bool = False,
     provider: Optional[str] = None,
     chunk_size: Optional[int] = None,
@@ -233,9 +234,12 @@ def process_directory_create(
         api_base: API base URL
         model: Model to use
         content_type: Type of content to generate (qa, summary, cot, cot-enhance)
-        num_pairs: Target number of QA pairs or examples
+        num_pairs: Target number of QA pairs or examples (total per document)
+        num_pairs_per_chunk: Number of QA pairs per chunk (takes precedence over num_pairs)
         verbose: Show detailed progress
         provider: LLM provider to use
+        chunk_size: Size of text chunks
+        chunk_overlap: Overlap between chunks
     
     Returns:
         Dictionary with processing results
@@ -310,7 +314,8 @@ def process_directory_create(
                     verbose,
                     provider=provider,
                     chunk_size=chunk_size,
-                    chunk_overlap=chunk_overlap
+                    chunk_overlap=chunk_overlap,
+                    num_pairs_per_chunk=num_pairs_per_chunk
                 )
                 
                 # Record success


### PR DESCRIPTION
# Pull Request

## Description

Implemented a new `num_pairs_per_chunk` parameter that scales QA generation based on the number of chunks in a document.
Overall - 
- Added num_pairs_per_chunk parameter to generate_qa_pairs() and process_documents()
- Parameter priority: num_pairs_per_chunk takes precedence over num_pairs
- Backward compatible: existing num_pairs usage continues to work unchanged

**Old way (still functions):**
  synthetic-data-kit create document.txt --type qa --num-pairs 25
  Result: 25 total pairs regardless of document size
**New way:**
  synthetic-data-kit create document.txt --type qa --num-pairs-per-chunk 2
  Result: 2 pairs per chunk
    - 29 chunks = 58 pairs
    - 200 chunks = 400 pairs

Tests 
- Added 3 new unit tests for per-chunk mode, priority logic, and integration
<img width="2560" height="494" alt="image" src="https://github.com/user-attachments/assets/45a80417-12f5-4c5e-a7ec-b4c8225eabb8" />

Fixes #63 
## Type of change

Please non-releavant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update